### PR TITLE
Fix visualization tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@ limitations under the License.
         <metainf-services.version>1.7</metainf-services.version>
         <mockito.version>2.18.3</mockito.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <testng.version>6.11</testng.version>
+        <testng.version>6.14.3</testng.version>
 
         <!-- Javadoc links -->
         <brics-automaton.apidocs>http://www.brics.dk/automaton/doc</brics-automaton.apidocs>

--- a/visualization/dot-visualizer/src/test/java/net/automatalib/visualization/dot/DOTFrameTest.java
+++ b/visualization/dot-visualizer/src/test/java/net/automatalib/visualization/dot/DOTFrameTest.java
@@ -41,7 +41,7 @@ public class DOTFrameTest {
     }
 
     // Headless GUI testing is a pain. Therefore just check that we don't throw any exceptions for now.
-    @Test(timeOut = 10000)
+    @Test(timeOut = 30000)
     public void testFrame() throws InvocationTargetException, InterruptedException {
 
         if (JVMUtil.getCanonicalSpecVersion() > 8) {

--- a/visualization/jung-visualizer/src/test/java/net/automatalib/visualization/jung/ProviderTest.java
+++ b/visualization/jung-visualizer/src/test/java/net/automatalib/visualization/jung/ProviderTest.java
@@ -50,7 +50,7 @@ public class ProviderTest {
     }
 
     // Headless GUI testing is a pain. Therefore just check that we don't throw any exceptions for now.
-    @Test(dependsOnMethods = "testProviderConfiguration", timeOut = 10000)
+    @Test(dependsOnMethods = "testProviderConfiguration", timeOut = 30000)
     public void testDisplay() throws InterruptedException, InvocationTargetException {
 
         if (JVMUtil.getCanonicalSpecVersion() > 8) {


### PR DESCRIPTION
- Update TestNG to the most recent version (fixes ArrayIndexOutOfBoundsException)
- Increase timeout to 30s (times out on my mac otherwise)