### PR TITLE
Fixed Inverted Determinization Logic for BricsDFA Construction

### DIFF
--- a/adapters/brics/src/main/java/net/automatalib/brics/BricsDFA.java
+++ b/adapters/brics/src/main/java/net/automatalib/brics/BricsDFA.java
@@ -67,7 +67,7 @@ public class BricsDFA extends AbstractBricsAutomaton implements DFA<State, Chara
     }
 
     private static Automaton requireDeterministic(Automaton aut) {
-        if (aut.isDeterministic()) {
+        if (!aut.isDeterministic()) {
             aut.determinize();
         }
         return aut;


### PR DESCRIPTION
This change makes the code slightly less confusing to read.  
_(Although I'm pretty sure this will not change behavior because the correct check is done inside of `BasicOperations.determinize();` as well.)_