### PR TITLE
Fix a bug in the TarjanSCCVisitor regarding the stack ordering

### DIFF
--- a/util/src/main/java/net/automatalib/util/graphs/scc/TarjanSCCVisitor.java
+++ b/util/src/main/java/net/automatalib/util/graphs/scc/TarjanSCCVisitor.java
@@ -16,6 +16,8 @@
 package net.automatalib.util.graphs.scc;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.ListIterator;
 
@@ -87,19 +89,22 @@ public class TarjanSCCVisitor<N, E> implements GraphTraversalVisitor<N, E, Tarja
         currentSccRecordStack.add(data);
         currentSccNodeStack.add(node);
 
+        final TarjanSCCRecord res = records.get(node);
+
         // finished the initial node of this SCC
         if (data.sccId == data.number) {
-            final int currScc = data.sccId;
             int numOfNodes = 0;
+
+            Collections.sort(currentSccRecordStack, new TarjanSCCRecordComperator());
             final ListIterator<TarjanSCCRecord> iter = currentSccRecordStack.listIterator(currentSccRecordStack.size());
 
             while (iter.hasPrevious()) {
                 final TarjanSCCRecord prev = iter.previous();
-                if (prev.sccId == currScc) {
-                    numOfNodes++;
-                    prev.sccId = SCC_FINISHED;
-                    iter.remove();
-                } else {
+
+                numOfNodes++;
+                prev.sccId = SCC_FINISHED;
+                iter.remove();
+                if (prev == res) {
                     break;
                 }
             }
@@ -157,4 +162,10 @@ public class TarjanSCCVisitor<N, E> implements GraphTraversalVisitor<N, E, Tarja
         return (records.get(node) != null);
     }
 
+    private class TarjanSCCRecordComperator implements Comparator<TarjanSCCRecord> {
+        @Override
+        public int compare(TarjanSCCRecord o1, TarjanSCCRecord o2) {
+            return o1.number - o2.number;
+        }
+    }
 }

--- a/util/src/main/java/net/automatalib/util/graphs/scc/TarjanSCCVisitor.java
+++ b/util/src/main/java/net/automatalib/util/graphs/scc/TarjanSCCVisitor.java
@@ -16,8 +16,6 @@
 package net.automatalib.util.graphs.scc;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.ListIterator;
 
@@ -81,33 +79,27 @@ public class TarjanSCCVisitor<N, E> implements GraphTraversalVisitor<N, E, Tarja
     @Override
     public boolean startExploration(N node, TarjanSCCRecord data) {
         records.put(node, data);
+        currentSccRecordStack.add(data);
+        currentSccNodeStack.add(node);
         return true;
     }
 
     @Override
     public void finishExploration(N node, TarjanSCCRecord data) {
-        currentSccRecordStack.add(data);
-        currentSccNodeStack.add(node);
-
-        final TarjanSCCRecord res = records.get(node);
-
         // finished the initial node of this SCC
         if (data.sccId == data.number) {
             int numOfNodes = 0;
-
-            Collections.sort(currentSccRecordStack, new TarjanSCCRecordComperator());
             final ListIterator<TarjanSCCRecord> iter = currentSccRecordStack.listIterator(currentSccRecordStack.size());
 
-            while (iter.hasPrevious()) {
+            final int nodeId = data.number;
+            int prevId;
+            do {
                 final TarjanSCCRecord prev = iter.previous();
-
+                prevId = prev.number;
                 numOfNodes++;
                 prev.sccId = SCC_FINISHED;
                 iter.remove();
-                if (prev == res) {
-                    break;
-                }
-            }
+            } while (prevId != nodeId);
 
             final int nodeStackSize = currentSccNodeStack.size();
             final List<N> sccNodes = currentSccNodeStack.subList(nodeStackSize - numOfNodes, nodeStackSize);
@@ -130,7 +122,7 @@ public class TarjanSCCVisitor<N, E> implements GraphTraversalVisitor<N, E, Tarja
         }
 
         if (rec.sccId != SCC_FINISHED) {
-            int tgtId = rec.sccId;
+            int tgtId = rec.number;
             /*
              * if our successor has a lower scc id than we do, it belongs to an SCC of one of our ascendants,
              * Thus we have detected a cycle and belong to the same SCC.
@@ -162,10 +154,4 @@ public class TarjanSCCVisitor<N, E> implements GraphTraversalVisitor<N, E, Tarja
         return (records.get(node) != null);
     }
 
-    private class TarjanSCCRecordComperator implements Comparator<TarjanSCCRecord> {
-        @Override
-        public int compare(TarjanSCCRecord o1, TarjanSCCRecord o2) {
-            return o1.number - o2.number;
-        }
-    }
 }

--- a/util/src/test/java/net/automatalib/util/graphs/SCCTest.java
+++ b/util/src/test/java/net/automatalib/util/graphs/SCCTest.java
@@ -218,6 +218,7 @@ public class SCCTest {
         graph.connect(n1, n0);
         graph.connect(n2, n0);
 
+        @SuppressWarnings("unchecked")
         Set<Set<Integer>> expectedSCCs =
                 Sets.newHashSet(Sets.newHashSet(n3), Sets.newHashSet(n7),
                                 Sets.newHashSet(n1), Sets.newHashSet(n0, n2, n4, n5, n6, n8, n9));
@@ -228,7 +229,7 @@ public class SCCTest {
          * An invariant of this algorithm is that every node in the input graph should be maintained in the result set.
          */
         Set<Integer> nodeSet = Sets.newHashSet(n0, n1, n2, n3, n4, n5, n6, n7, n8, n9);
-        computedSCCs.stream().forEach(set -> nodeSet.removeAll(set));
+        computedSCCs.forEach(nodeSet::removeAll);
         Assert.assertEquals(nodeSet.size(), 0);
 
         Assert.assertEquals(computedSCCs, expectedSCCs);

--- a/util/src/test/java/net/automatalib/util/graphs/SCCTest.java
+++ b/util/src/test/java/net/automatalib/util/graphs/SCCTest.java
@@ -128,7 +128,7 @@ public class SCCTest {
     }
 
     /*
-     * This third example is taken from the following slide deck:
+     * This example is taken from the following slide deck:
      * http://www.cse.cuhk.edu.hk/~taoyf/course/comp3506/lec/scc.pdf
      */
     @Test
@@ -179,6 +179,60 @@ public class SCCTest {
 
         Assert.assertEquals(computedSCCs.size(), 4);
         Assert.assertEquals(computedSCCs, expectedSCCs);
+    }
+
+    @Test
+    public void testExample5() {
+        CompactSimpleGraph<Void> graph = new CompactSimpleGraph<>();
+        Integer n0, n1, n2, n3, n4, n5, n6, n7, n8, n9;
+
+        n0 = graph.addNode();
+        n1 = graph.addNode();
+        n2 = graph.addNode();
+        n3 = graph.addNode();
+        n4 = graph.addNode();
+        n5 = graph.addNode();
+        n6 = graph.addNode();
+        n7 = graph.addNode();
+        n8 = graph.addNode();
+        n9 = graph.addNode();
+
+        graph.connect(n5, n7);
+        graph.connect(n0, n8);
+        graph.connect(n9, n4);
+        graph.connect(n9, n7);
+        graph.connect(n1, n5);
+        graph.connect(n8, n4);
+        graph.connect(n8, n2);
+        graph.connect(n5, n9);
+        graph.connect(n8, n7);
+        graph.connect(n5, n6);
+        graph.connect(n4, n7);
+        graph.connect(n0, n5);
+        graph.connect(n6, n8);
+        graph.connect(n1, n6);
+        graph.connect(n3, n9);
+        graph.connect(n4, n6);
+        graph.connect(n9, n5);
+        graph.connect(n2, n7);
+        graph.connect(n1, n0);
+        graph.connect(n2, n0);
+
+        Set<Set<Integer>> expectedSCCs =
+                Sets.newHashSet(Sets.newHashSet(n3), Sets.newHashSet(n7),
+                                Sets.newHashSet(n1), Sets.newHashSet(n0, n2, n4, n5, n6, n8, n9));
+
+        Set<Set<Integer>> computedSCCs = computeSCCs(graph);
+
+        /*
+         * An invariant of this algorithm is that every node in the input graph should be maintained in the result set.
+         */
+        Set<Integer> nodeSet = Sets.newHashSet(n0, n1, n2, n3, n4, n5, n6, n7, n8, n9);
+        computedSCCs.stream().forEach(set -> nodeSet.removeAll(set));
+        Assert.assertEquals(nodeSet.size(), 0);
+
+        Assert.assertEquals(computedSCCs, expectedSCCs);
+        Assert.assertEquals(computedSCCs.size(), 4);
     }
 
     /*


### PR DESCRIPTION
While working with the automata lib, I came across another bug related to #21.

There are cases, where the sccId is not uniform for a single SCC at the end. Instead, the stack ordering is the most important thing. It is possible that a single SCC is constructed using more than one sccID on the stack. Luckily, it is possible to recreate the stack order in the visitor by sorting the records on the stack by the number attribute.

A new test case affected by this problem is added as part of this PR.