### PR TITLE
Fix to enquote the output of mealy machines in the TFAWriter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Removed `IOUtil#copy`, `IOUtil.skip`, `NullOutputStream`. Use the Guava equivalents from `ByteStreams` and `CharStreams`.
 
 
+### Fixed
+
+* Correctly enquote outputs containing whitespaces in `TAFWriter` ([#37](https://github.com/LearnLib/automatalib/issues/37), thanks to [Alexander Schieweck](https://github.com/aschieweck)).
+
+
 ## [0.9.0](https://github.com/LearnLib/automatalib/releases/tag/automatalib-0.9.0) - 2020-02-05
 
 [Full changelog](https://github.com/LearnLib/automatalib/compare/automatalib-0.8.0...automatalib-0.9.0)

--- a/serialization/taf/src/main/java/net/automatalib/serialization/taf/writer/TAFWriter.java
+++ b/serialization/taf/src/main/java/net/automatalib/serialization/taf/writer/TAFWriter.java
@@ -165,8 +165,7 @@ public final class TAFWriter {
         writeIndent();
         writeStringCollection(symbols);
         if (output != null) {
-            String escapedOutput = StringUtil.enquoteIfNecessary(output.toString());
-            out.append(" / ").append(escapedOutput);
+            out.append(" / ").append(StringUtil.enquoteIfNecessary(output.toString()));
         }
         out.append(" -> ").append(target).append(System.lineSeparator());
     }

--- a/serialization/taf/src/main/java/net/automatalib/serialization/taf/writer/TAFWriter.java
+++ b/serialization/taf/src/main/java/net/automatalib/serialization/taf/writer/TAFWriter.java
@@ -165,7 +165,8 @@ public final class TAFWriter {
         writeIndent();
         writeStringCollection(symbols);
         if (output != null) {
-            out.append(" / ").append(output.toString());
+            String escapedOutput = StringUtil.enquoteIfNecessary(output.toString());
+            out.append(" / ").append(escapedOutput);
         }
         out.append(" -> ").append(target).append(System.lineSeparator());
     }


### PR DESCRIPTION
Closes #37.