### PR TITLE
feed an LTL formula to LTSMin via a file

### DIFF
--- a/modelchecking/ltsmin/src/main/java/net/automatalib/modelcheckers/ltsmin/AbstractLTSmin.java
+++ b/modelchecking/ltsmin/src/main/java/net/automatalib/modelcheckers/ltsmin/AbstractLTSmin.java
@@ -184,11 +184,9 @@ public abstract class AbstractLTSmin<I, A, R> implements ModelChecker<I, A, Stri
             // create a file that will contain the LTL of the specification
             ltlFile = File.createTempFile("formula", ".ltl");
 
-            try {
+            try (FileWriter writer = new FileWriter(ltlFile)) {
                 // write to the file
-                FileWriter writer = new FileWriter(ltlFile);
                 writer.write(formula);
-                writer.close();
             } catch (IOException ioe) {
                 if (!keepFiles && !ltlFile.delete()) {
                     LOGGER.warn("Could not delete file: " + ltlFile.getAbsolutePath());

--- a/modelchecking/ltsmin/src/main/java/net/automatalib/modelcheckers/ltsmin/AbstractLTSmin.java
+++ b/modelchecking/ltsmin/src/main/java/net/automatalib/modelcheckers/ltsmin/AbstractLTSmin.java
@@ -16,8 +16,8 @@
 package net.automatalib.modelcheckers.ltsmin;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -25,6 +25,7 @@ import java.util.function.Function;
 
 import com.google.common.collect.Lists;
 import net.automatalib.AutomataLibSettings;
+import net.automatalib.commons.util.IOUtil;
 import net.automatalib.commons.util.process.ProcessUtil;
 import net.automatalib.exception.ModelCheckingException;
 import net.automatalib.modelchecking.ModelChecker;
@@ -181,12 +182,12 @@ public abstract class AbstractLTSmin<I, A, R> implements ModelChecker<I, A, Stri
         final File ltlFile;
 
         try {
-            // create a file that will contain the LTL of the specification
+            // write LTL formula to a file because long formulae may cause problems as direct inputs to LTSmin
             ltlFile = File.createTempFile("formula", ".ltl");
 
-            try (FileWriter writer = new FileWriter(ltlFile)) {
+            try (Writer w = IOUtil.asBufferedUTF8Writer(ltlFile)) {
                 // write to the file
-                writer.write(formula);
+                w.write(formula);
             } catch (IOException ioe) {
                 if (!keepFiles && !ltlFile.delete()) {
                     LOGGER.warn("Could not delete file: " + ltlFile.getAbsolutePath());

--- a/modelchecking/ltsmin/src/test/java/net/automatalib/modelcheckers/ltsmin/AbstractLTSminTest.java
+++ b/modelchecking/ltsmin/src/test/java/net/automatalib/modelcheckers/ltsmin/AbstractLTSminTest.java
@@ -88,5 +88,18 @@ public abstract class AbstractLTSminTest<A, R extends Output<String, ?>> {
         R ce = getModelChecker().findCounterExample(automaton, alphabet, falseProperty);
         Assert.assertNotNull(ce);
         Assert.assertEquals(counterExample.computeOutput(input), ce.computeOutput(input));
+
+        StringBuilder complexProperty = new StringBuilder();
+        final int maxNumOperators = 90;
+        for (int numOperators = 0; numOperators < maxNumOperators; ++numOperators) {
+            for (int i = 0; i < numOperators; ++i) {
+                complexProperty.append("X ");
+            }
+            complexProperty.append(falseProperty);
+            if (numOperators + 1 < maxNumOperators) {
+                complexProperty.append(" && ");
+            }
+        }
+        getModelChecker().findCounterExample(automaton, alphabet, complexProperty.toString());
     }
 }

--- a/modelchecking/ltsmin/src/test/java/net/automatalib/modelcheckers/ltsmin/AbstractLTSminTest.java
+++ b/modelchecking/ltsmin/src/test/java/net/automatalib/modelcheckers/ltsmin/AbstractLTSminTest.java
@@ -88,18 +88,26 @@ public abstract class AbstractLTSminTest<A, R extends Output<String, ?>> {
         R ce = getModelChecker().findCounterExample(automaton, alphabet, falseProperty);
         Assert.assertNotNull(ce);
         Assert.assertEquals(counterExample.computeOutput(input), ce.computeOutput(input));
+    }
 
-        StringBuilder complexProperty = new StringBuilder();
-        final int maxNumOperators = 90;
-        for (int numOperators = 0; numOperators < maxNumOperators; ++numOperators) {
-            for (int i = 0; i < numOperators; ++i) {
-                complexProperty.append("X ");
-            }
-            complexProperty.append(falseProperty);
-            if (numOperators + 1 < maxNumOperators) {
-                complexProperty.append(" && ");
-            }
+    /**
+     * It appears that the input buffer of LTSmin for input formulae is limited to 8192 (2^13) bytes. As a result, we
+     * need to pass longer formulae as a file. This test checks for compatibility with long formulae.
+     */
+    @Test
+    public void testLongFormula() {
+        final StringBuilder builder = new StringBuilder();
+        final int length = falseProperty.length();
+        final int max = ((1 << 13) / length) + 1;
+
+        for (int i = 0; i < max; i++) {
+            builder.append(falseProperty);
+            builder.append(" && ");
         }
-        getModelChecker().findCounterExample(automaton, alphabet, complexProperty.toString());
+        builder.append(falseProperty);
+
+        final R ce = getModelChecker().findCounterExample(automaton, alphabet, builder.toString());
+        Assert.assertNotNull(ce);
+        Assert.assertEquals(counterExample.computeOutput(input), ce.computeOutput(input));
     }
 }


### PR DESCRIPTION
Due to the limitation of OS, long LTL formulas cannot be fed via the command line. This PR modifies to feed LTL formulas via a temporary file so that long LTL formulas can also be fed to LTSMin.