### PR TITLE
random 1SEVPA: correct probability for initial location

### DIFF
--- a/util/src/main/java/net/automatalib/util/automata/random/RandomAutomata.java
+++ b/util/src/main/java/net/automatalib/util/automata/random/RandomAutomata.java
@@ -99,7 +99,7 @@ public final class RandomAutomata {
                                                         double initialRetTransProb,
                                                         boolean minimize,
                                                         DefaultOneSEVPA<I> result) {
-        result.addInitialLocation(r.nextDouble() < initialRetTransProb);
+        result.addInitialLocation(r.nextDouble() < acceptanceProb);
 
         for (int i = 0; i < locCount - 1; i++) {
             if (alphabet.getNumInternals() == 0 || r.nextDouble() < initialRetTransProb) {


### PR DESCRIPTION
Hello,
I stumbled on a mistake in the code to generate a random 1SEVPA. The probability that initial location is accepting don't use the correct variable.