### PR TITLE
Add Tabakov-Vardi random automata generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 * AutomataLib now supports JPMS modules. Many of the artifacts now provide a `module-info` descriptor with the exception of `automata-brics`, `automata-modelchecking-m3c`, and `automata-jung-visualizer` which do not have modular dependencies and only provide an `Automatic-Module-Name` in their respective `MANIFEST.MF`s. As a consequence of this, the distribution artifacts (for Maven-less environments) also only provide an `Automatic-Module-Name`. Note that while this is a Java 9+ feature, AutomataLib still supports Java 8 byte code for the remaining class files.
-* Added `TabakovVardiRandomAutomata` that allows for creating Tabakov-Vardi random automata (in particular, NFAs).
+* Added `TabakovVardiRandomAutomata` that allows for creating Tabakov-Vardi random automata, in particular, NFAs (thanks to [John Nicol](https://github.com/jn1z)).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 * AutomataLib now supports JPMS modules. Many of the artifacts now provide a `module-info` descriptor with the exception of `automata-brics`, `automata-modelchecking-m3c`, and `automata-jung-visualizer` which do not have modular dependencies and only provide an `Automatic-Module-Name` in their respective `MANIFEST.MF`s. As a consequence of this, the distribution artifacts (for Maven-less environments) also only provide an `Automatic-Module-Name`. Note that while this is a Java 9+ feature, AutomataLib still supports Java 8 byte code for the remaining class files.
+* Added `TabakovVardiRandomAutomata` that allows for creating Tabakov-Vardi random automata (in particular, NFAs).
 
 ### Changed
 

--- a/util/src/main/java/net/automatalib/util/automaton/minimizer/paigetarjan/PaigeTarjanMinimization.java
+++ b/util/src/main/java/net/automatalib/util/automaton/minimizer/paigetarjan/PaigeTarjanMinimization.java
@@ -155,7 +155,7 @@ public final class PaigeTarjanMinimization {
     /**
      * Minimizes the given automaton depending on the given partitioning function. The {@code sinkClassification} is
      * used to describe the signature of the sink state ("successor" of undefined transitions) and may introduce a new,
-     * on-thy-fly equivalence class if it doesn't match a signature of any existing state. See the {@link
+     * on-the-fly equivalence class if it doesn't match a signature of any existing state. See the {@link
      * StateSignature} class for creating signatures for existing states.
      *
      * @param automaton

--- a/util/src/main/java/net/automatalib/util/automaton/random/RandomICAutomatonGenerator.java
+++ b/util/src/main/java/net/automatalib/util/automaton/random/RandomICAutomatonGenerator.java
@@ -236,7 +236,7 @@ public class RandomICAutomatonGenerator<SP, TP> {
 
     /**
      * Generates an initially connected (IC) deterministic automaton with the given parameters. Note that the automaton
-     * will <b>not</b> be minized.
+     * will <b>not</b> be minimized.
      *
      * @param numStates
      *         the number of states of the resulting automaton

--- a/util/src/main/java/net/automatalib/util/automaton/random/TabakovVardiRandomAutomata.java
+++ b/util/src/main/java/net/automatalib/util/automaton/random/TabakovVardiRandomAutomata.java
@@ -20,11 +20,12 @@ import java.util.Random;
 import net.automatalib.alphabet.Alphabet;
 import net.automatalib.automaton.concept.StateIDs;
 import net.automatalib.automaton.fsa.MutableNFA;
+import net.automatalib.automaton.fsa.NFA;
 import net.automatalib.automaton.fsa.impl.CompactNFA;
 import net.automatalib.common.util.random.RandomUtil;
 
 /**
- * A generator for random automata (in particular, NFAs) using Tabakov and Vardi's approach, described in the paper
+ * A generator for random {@link NFA}s as described in the paper
  * <a href="https://doi.org/10.1007/11591191_28">Experimental Evaluation of Classical Automata Constructions</a>
  * by Deian Tabakov and Moshe Y&nbsp;Vardi.
  */
@@ -34,7 +35,7 @@ public final class TabakovVardiRandomAutomata {
     }
 
     /**
-     * Generate random NFA of given size, with specified transition and acceptance densities.
+     * Generates a random {@link NFA} with the given size, transition density, and acceptance density.
      *
      * @param r
      *      random instance
@@ -45,7 +46,9 @@ public final class TabakovVardiRandomAutomata {
      * @param ad
      *      acceptance density, in (0,1]. 0.5 is the usual value
      * @param alphabet
-     *      alphabet
+     *      the input symbols to consider when determining successors
+     * @param <I>
+     *     input symbol type
      * @return
      *      a random NFA, not necessarily connected
      */
@@ -55,18 +58,20 @@ public final class TabakovVardiRandomAutomata {
     }
 
     /**
-     * Generate random NFA of given size, with fixed number of edges (per letter) and accept states.
+     * Generates a random {@link NFA} with the given size, number of edges (per letter), number of accepting states.
      *
      * @param r
      *      random instance
      * @param size
      *      number of states
      * @param edgeNum
-     *      number of edges (per letter)
+     *      number of edges (per input)
      * @param acceptNum
      *      number of accepting states (at least one)
      * @param alphabet
-     *      alphabet
+     *      the input symbols to consider when determining successors
+     * @param <I>
+     *     input symbol type
      * @return
      *      a random NFA, not necessarily connected
      */
@@ -76,18 +81,21 @@ public final class TabakovVardiRandomAutomata {
     }
 
     /**
-     * Generates a random NFA with a given size, number of edges (per letter), and accept states and writes the result to the given {@link MutableNFA}.
+     * Generates a random NFA with the given size, number of edges (per letter), and number of accepting states, written to the given {@link MutableNFA}.
+     * Note that the output automaton must be empty.
      *
      * @param r
      *      random instance
      * @param size
      *      number of states
      * @param edgeNum
-     *      number of edges (per letter)
+     *      number of edges (per input)
      * @param acceptNum
      *      number of accepting states (at least one)
      * @param alphabet
-     *      alphabet
+     *      the input symbols to consider when determining successors
+     * @param out
+     *      the (mutable) automaton to write the random structure to
      * @param <S>
      *     state type
      * @param <I>

--- a/util/src/main/java/net/automatalib/util/automaton/random/TabakovVardiRandomAutomata.java
+++ b/util/src/main/java/net/automatalib/util/automaton/random/TabakovVardiRandomAutomata.java
@@ -44,8 +44,8 @@ public final class TabakovVardiRandomAutomata {
      * @return
      *      a random NFA, not necessarily connected
      */
-    public static CompactNFA<Integer> generateNFA(
-            Random r, int size, float td, float ad, Alphabet<Integer> alphabet) {
+    public static <I> CompactNFA<I> generateNFA(
+            Random r, int size, float td, float ad, Alphabet<I> alphabet) {
         return generateNFA(r, size, Math.round(td * size), Math.round(ad * size), alphabet);
     }
 
@@ -65,12 +65,12 @@ public final class TabakovVardiRandomAutomata {
      * @return
      *      a random NFA, not necessarily connected
      */
-    public static CompactNFA<Integer> generateNFA(
-            Random r, int size, int edgeNum, int acceptNum, Alphabet<Integer> alphabet) {
+    public static <I> CompactNFA<I> generateNFA(
+            Random r, int size, int edgeNum, int acceptNum, Alphabet<I> alphabet) {
         assert acceptNum > 0 && acceptNum <= size;
         assert edgeNum >= 0 && edgeNum <= size*size;
 
-        CompactNFA<Integer> nfa = basicNFA(size, alphabet);
+        CompactNFA<I> nfa = basicNFA(size, alphabet);
 
         // Set final states other than the initial state.
         // We want exactly acceptNum-1 of them, from the elements [1,size).
@@ -81,7 +81,7 @@ public final class TabakovVardiRandomAutomata {
         }
 
         // For each letter, add edgeNum transitions.
-        for (int a: alphabet) {
+        for (I a: alphabet) {
             for (int edgeIndex: RandomUtil.distinctIntegers(r, edgeNum, size*size)) {
                 nfa.addTransition(edgeIndex / size, a, edgeIndex % size);
             }
@@ -91,8 +91,8 @@ public final class TabakovVardiRandomAutomata {
     }
 
     // Helper method to generate NFA with initial accepting state.
-    private static CompactNFA<Integer> basicNFA(int size, Alphabet<Integer> alphabet) {
-        CompactNFA<Integer> basicNFA = new CompactNFA<>(alphabet);
+    private static <I> CompactNFA<I> basicNFA(int size, Alphabet<I> alphabet) {
+        CompactNFA<I> basicNFA = new CompactNFA<>(alphabet);
 
         // Create states
         for (int i = 0; i < size; i++) {

--- a/util/src/main/java/net/automatalib/util/automaton/random/TabakovVardiRandomAutomata.java
+++ b/util/src/main/java/net/automatalib/util/automaton/random/TabakovVardiRandomAutomata.java
@@ -30,6 +30,7 @@ import net.automatalib.common.util.random.RandomUtil;
  * by Deian Tabakov and Moshe Y&nbsp;Vardi.
  */
 public final class TabakovVardiRandomAutomata {
+
     private TabakovVardiRandomAutomata() {
         // prevent instantiation
     }
@@ -38,22 +39,21 @@ public final class TabakovVardiRandomAutomata {
      * Generates a random {@link NFA} with the given size, transition density, and acceptance density.
      *
      * @param r
-     *      random instance
+     *         random instance
      * @param size
-     *      number of states
+     *         number of states
      * @param td
-     *      transition density, in [0,size]
+     *         transition density, in [0,size]
      * @param ad
-     *      acceptance density, in (0,1]. 0.5 is the usual value
+     *         acceptance density, in (0,1]. 0.5 is the usual value
      * @param alphabet
-     *      the input symbols to consider when determining successors
+     *         the input symbols to consider when determining successors
      * @param <I>
-     *     input symbol type
-     * @return
-     *      a random NFA, not necessarily connected
+     *         input symbol type
+     *
+     * @return a random NFA, not necessarily connected
      */
-    public static <I> CompactNFA<I> generateNFA(
-            Random r, int size, float td, float ad, Alphabet<I> alphabet) {
+    public static <I> CompactNFA<I> generateNFA(Random r, int size, float td, float ad, Alphabet<I> alphabet) {
         return generateNFA(r, size, Math.round(td * size), Math.round(ad * size), alphabet);
     }
 
@@ -61,54 +61,57 @@ public final class TabakovVardiRandomAutomata {
      * Generates a random {@link NFA} with the given size, number of edges (per letter), number of accepting states.
      *
      * @param r
-     *      random instance
+     *         random instance
      * @param size
-     *      number of states
+     *         number of states
      * @param edgeNum
-     *      number of edges (per input)
+     *         number of edges (per input)
      * @param acceptNum
-     *      number of accepting states (at least one)
+     *         number of accepting states (at least one)
      * @param alphabet
-     *      the input symbols to consider when determining successors
+     *         the input symbols to consider when determining successors
      * @param <I>
-     *     input symbol type
-     * @return
-     *      a random NFA, not necessarily connected
+     *         input symbol type
+     *
+     * @return a random NFA, not necessarily connected
      */
-    public static <I> CompactNFA<I> generateNFA(
-            Random r, int size, int edgeNum, int acceptNum, Alphabet<I> alphabet) {
+    public static <I> CompactNFA<I> generateNFA(Random r, int size, int edgeNum, int acceptNum, Alphabet<I> alphabet) {
         return generateNFA(r, size, edgeNum, acceptNum, alphabet, new CompactNFA<>(alphabet));
     }
 
     /**
-     * Generates a random NFA with the given size, number of edges (per letter), and number of accepting states, written to the given {@link MutableNFA}.
-     * Note that the output automaton must be empty.
+     * Generates a random NFA with the given size, number of edges (per letter), and number of accepting states, written
+     * to the given {@link MutableNFA}. Note that the output automaton must be empty.
      *
      * @param r
-     *      random instance
+     *         random instance
      * @param size
-     *      number of states
+     *         number of states
      * @param edgeNum
-     *      number of edges (per input)
+     *         number of edges (per input)
      * @param acceptNum
-     *      number of accepting states (at least one)
+     *         number of accepting states (at least one)
      * @param alphabet
-     *      the input symbols to consider when determining successors
+     *         the input symbols to consider when determining successors
      * @param out
-     *      the (mutable) automaton to write the random structure to
+     *         the (mutable) automaton to write the random structure to
      * @param <S>
-     *     state type
+     *         state type
      * @param <I>
-     *     input symbol type
+     *         input symbol type
      * @param <A>
-     *     automaton type
-     * @return
-     *      the {@code out} parameter after the contents have been written to it
+     *         automaton type
+     *
+     * @return the {@code out} parameter after the contents have been written to it
      */
-    public static <S, I, A extends MutableNFA<S, I>> A generateNFA(
-            Random r, int size, int edgeNum, int acceptNum, Alphabet<I> alphabet, A out) {
+    public static <S, I, A extends MutableNFA<S, I>> A generateNFA(Random r,
+                                                                   int size,
+                                                                   int edgeNum,
+                                                                   int acceptNum,
+                                                                   Alphabet<I> alphabet,
+                                                                   A out) {
         assert acceptNum > 0 && acceptNum <= size;
-        assert edgeNum >= 0 && edgeNum <= size*size;
+        assert edgeNum >= 0 && edgeNum <= size * size;
 
         initNFA(size, out);
         final StateIDs<S> stateIDs = out.stateIDs();
@@ -122,8 +125,8 @@ public final class TabakovVardiRandomAutomata {
         }
 
         // For each letter, add edgeNum transitions.
-        for (I a: alphabet) {
-            for (int edgeIndex: RandomUtil.distinctIntegers(r, edgeNum, size*size)) {
+        for (I a : alphabet) {
+            for (int edgeIndex : RandomUtil.distinctIntegers(r, edgeNum, size * size)) {
                 out.addTransition(stateIDs.getState(edgeIndex / size), a, stateIDs.getState(edgeIndex % size));
             }
         }

--- a/util/src/main/java/net/automatalib/util/automaton/random/TabakovVardiRandomAutomata.java
+++ b/util/src/main/java/net/automatalib/util/automaton/random/TabakovVardiRandomAutomata.java
@@ -21,15 +21,18 @@ import net.automatalib.alphabet.Alphabet;
 import net.automatalib.automaton.fsa.impl.CompactNFA;
 import net.automatalib.common.util.random.RandomUtil;
 
+/**
+ * A generator for random automata (in particular, NFAs) using Tabakov and Vardi's approach, described in the paper
+ * <a href="https://doi.org/10.1007/11591191_28">Experimental Evaluation of Classical Automata Constructions</a>
+ * by Deian Tabakov and Moshe Y&nbsp;Vardi.
+ */
 public final class TabakovVardiRandomAutomata {
     private TabakovVardiRandomAutomata() {
         // prevent instantiation
     }
 
     /**
-     * Generate random NFA using Tabakov and Vardi's approach, described in the paper
-     * <a href="https://doi.org/10.1007/11591191_28">Experimental Evaluation of Classical Automata Constructions</a>
-     * by Deian Tabakov and Moshe Y. Vardi.
+     * Generate random NFA of given size, with specified transition and acceptance densities.
      *
      * @param r
      *      random instance
@@ -50,7 +53,7 @@ public final class TabakovVardiRandomAutomata {
     }
 
     /**
-     * Generate random NFA, with fixed number of accept states and edges (per letter).
+     * Generate random NFA of given size, with fixed number of edges (per letter) and accept states.
      *
      * @param r
      *      random instance

--- a/util/src/main/java/net/automatalib/util/automaton/random/TabakovVardiRandomAutomata.java
+++ b/util/src/main/java/net/automatalib/util/automaton/random/TabakovVardiRandomAutomata.java
@@ -1,0 +1,107 @@
+/* Copyright (C) 2013-2024 TU Dortmund University
+ * This file is part of AutomataLib, http://www.automatalib.net/.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.automatalib.util.automaton.random;
+
+import java.util.Random;
+
+import net.automatalib.alphabet.Alphabet;
+import net.automatalib.automaton.fsa.impl.CompactNFA;
+import net.automatalib.common.util.random.RandomUtil;
+
+public final class TabakovVardiRandomAutomata {
+    private TabakovVardiRandomAutomata() {
+        // prevent instantiation
+    }
+
+    /**
+     * Generate random NFA using Tabakov and Vardi's approach, described in the paper
+     * <a href="https://doi.org/10.1007/11591191_28">Experimental Evaluation of Classical Automata Constructions</a>
+     * by Deian Tabakov and Moshe Y. Vardi.
+     *
+     * @param r
+     *      random instance
+     * @param size
+     *      number of states
+     * @param td
+     *      transition density, in [0,size]
+     * @param ad
+     *      acceptance density, in (0,1]. 0.5 is the usual value
+     * @param alphabet
+     *      alphabet
+     * @return
+     *      a random NFA, not necessarily connected
+     */
+    public static CompactNFA<Integer> generateNFA(
+            Random r, int size, float td, float ad, Alphabet<Integer> alphabet) {
+        return generateNFA(r, size, Math.round(td * size), Math.round(ad * size), alphabet);
+    }
+
+    /**
+     * Generate random NFA, with fixed number of accept states and edges (per letter).
+     *
+     * @param r
+     *      random instance
+     * @param size
+     *      number of states
+     * @param edgeNum
+     *      number of edges (per letter)
+     * @param acceptNum
+     *      number of accepting states (at least one)
+     * @param alphabet
+     *      alphabet
+     * @return
+     *      a random NFA, not necessarily connected
+     */
+    public static CompactNFA<Integer> generateNFA(
+            Random r, int size, int edgeNum, int acceptNum, Alphabet<Integer> alphabet) {
+        assert acceptNum > 0 && acceptNum <= size;
+        assert edgeNum >= 0 && edgeNum <= size*size;
+
+        CompactNFA<Integer> nfa = basicNFA(size, alphabet);
+
+        // Set final states other than the initial state.
+        // We want exactly acceptNum-1 of them, from the elements [1,size).
+        // This works even if acceptNum == 1.
+        int[] finalStates = RandomUtil.distinctIntegers(r, acceptNum - 1, 1, size);
+        for (int f : finalStates) {
+            nfa.setAccepting(f, true);
+        }
+
+        // For each letter, add edgeNum transitions.
+        for (int a: alphabet) {
+            for (int edgeIndex: RandomUtil.distinctIntegers(r, edgeNum, size*size)) {
+                nfa.addTransition(edgeIndex / size, a, edgeIndex % size);
+            }
+        }
+
+        return nfa;
+    }
+
+    // Helper method to generate NFA with initial accepting state.
+    private static CompactNFA<Integer> basicNFA(int size, Alphabet<Integer> alphabet) {
+        CompactNFA<Integer> basicNFA = new CompactNFA<>(alphabet);
+
+        // Create states
+        for (int i = 0; i < size; i++) {
+            basicNFA.addState(false);
+        }
+        // per the paper, the first state is always initial and accepting
+        basicNFA.setInitial(0, true);
+        basicNFA.setAccepting(0, true);
+        return basicNFA;
+    }
+}
+

--- a/util/src/test/java/net/automatalib/util/automaton/random/TabakovVardiRandomAutomataTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/random/TabakovVardiRandomAutomataTest.java
@@ -16,6 +16,7 @@
 package net.automatalib.util.automaton.random;
 
 import java.util.Random;
+import java.util.Set;
 
 import net.automatalib.alphabet.Alphabet;
 import net.automatalib.alphabet.impl.Alphabets;
@@ -32,8 +33,8 @@ class TabakovVardiRandomAutomataTest {
         float ad = 0.5f; // exactly 2 accepting states
         Alphabet<Integer> alphabet = Alphabets.integers(0, 1);
         CompactNFA<Integer> compactNFA = TabakovVardiRandomAutomata.generateNFA(r, size, td, ad, alphabet);
-        Assert.assertEquals(size, compactNFA.size());
-        Assert.assertEquals(1, compactNFA.getInitialStates().size());
+        Assert.assertEquals(compactNFA.size(), size);
+        Assert.assertEquals(compactNFA.getInitialStates().size(), 1);
         for (int s : compactNFA.getStates()) {
             if (s == 0 || s == 3) {
                 // 2 accepting states
@@ -42,19 +43,17 @@ class TabakovVardiRandomAutomataTest {
                 Assert.assertFalse(compactNFA.isAccepting(s));
             }
         }
-        StringBuilder sb = new StringBuilder();
-        for (int s : compactNFA.getStates()) {
-            sb.append(compactNFA.getTransitions(s, 0));
-        }
         // 5 transitions for 0
-        Assert.assertEquals("[0, 3][][1, 2][3]", sb.toString());
+        Assert.assertEquals(compactNFA.getTransitions(0, 0), Set.of(0,3));
+        Assert.assertTrue(compactNFA.getTransitions(1, 0).isEmpty());
+        Assert.assertEquals(compactNFA.getTransitions(2, 0), Set.of(1,2));
+        Assert.assertEquals(compactNFA.getTransitions(3, 0), Set.of(3));
 
-        sb = new StringBuilder();
-        for (int s : compactNFA.getStates()) {
-            sb.append(compactNFA.getTransitions(s, 1));
-        }
         // 5 transitions for 1
-        Assert.assertEquals("[3][1][0][1, 2]", sb.toString());
+        Assert.assertEquals(compactNFA.getTransitions(0, 1), Set.of(3));
+        Assert.assertEquals(compactNFA.getTransitions(1, 1), Set.of(1));
+        Assert.assertEquals(compactNFA.getTransitions(2, 1), Set.of(0));
+        Assert.assertEquals(compactNFA.getTransitions(3, 1), Set.of(1,2));
     }
 
     @Test
@@ -65,11 +64,11 @@ class TabakovVardiRandomAutomataTest {
         float ad = 0.5f; // exactly 1 accepting state
         Alphabet<Integer> alphabet = Alphabets.integers(0, 1);
         CompactNFA<Integer> compactNFA = TabakovVardiRandomAutomata.generateNFA(r, size, td, ad, alphabet);
-        Assert.assertEquals(size, compactNFA.size());
-        Assert.assertEquals(1, compactNFA.getInitialStates().size());
+        Assert.assertEquals(compactNFA.size(), size);
+        Assert.assertEquals(compactNFA.getInitialStates().size(), 1);
         Assert.assertTrue(compactNFA.isAccepting(0));
         Assert.assertFalse(compactNFA.isAccepting(1));
-        Assert.assertEquals(0, compactNFA.getTransitions(0).size());
-        Assert.assertEquals(0, compactNFA.getTransitions(1).size());
+        Assert.assertTrue(compactNFA.getTransitions(0).isEmpty());
+        Assert.assertTrue(compactNFA.getTransitions(1).isEmpty());
     }
 }

--- a/util/src/test/java/net/automatalib/util/automaton/random/TabakovVardiRandomAutomataTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/random/TabakovVardiRandomAutomataTest.java
@@ -1,0 +1,75 @@
+/* Copyright (C) 2013-2024 TU Dortmund University
+ * This file is part of AutomataLib, http://www.automatalib.net/.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.automatalib.util.automaton.random;
+
+import java.util.Random;
+
+import net.automatalib.alphabet.Alphabet;
+import net.automatalib.alphabet.impl.Alphabets;
+import net.automatalib.automaton.fsa.impl.CompactNFA;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+class TabakovVardiRandomAutomataTest {
+    @Test
+    void testGenerateNFA() {
+        Random r = new Random(42);
+        int size = 4;
+        float td = 1.25f; // exactly 5 transitions per letter
+        float ad = 0.5f; // exactly 2 accepting states
+        Alphabet<Integer> alphabet = Alphabets.integers(0, 1);
+        CompactNFA<Integer> compactNFA = TabakovVardiRandomAutomata.generateNFA(r, size, td, ad, alphabet);
+        Assert.assertEquals(size, compactNFA.size());
+        Assert.assertEquals(1, compactNFA.getInitialStates().size());
+        for (int s : compactNFA.getStates()) {
+            if (s == 0 || s == 3) {
+                // 2 accepting states
+                Assert.assertTrue(compactNFA.isAccepting(s));
+            } else {
+                Assert.assertFalse(compactNFA.isAccepting(s));
+            }
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int s : compactNFA.getStates()) {
+            sb.append(compactNFA.getTransitions(s, 0));
+        }
+        // 5 transitions for 0
+        Assert.assertEquals("[0, 3][][1, 2][3]", sb.toString());
+
+        sb = new StringBuilder();
+        for (int s : compactNFA.getStates()) {
+            sb.append(compactNFA.getTransitions(s, 1));
+        }
+        // 5 transitions for 1
+        Assert.assertEquals("[3][1][0][1, 2]", sb.toString());
+    }
+
+    @Test
+    void testGenerateNFAEdgeCase() {
+        Random r = new Random(42);
+        int size = 2;
+        float td = 0f; // 0 transitions
+        float ad = 0.5f; // exactly 1 accepting state
+        Alphabet<Integer> alphabet = Alphabets.integers(0, 1);
+        CompactNFA<Integer> compactNFA = TabakovVardiRandomAutomata.generateNFA(r, size, td, ad, alphabet);
+        Assert.assertEquals(size, compactNFA.size());
+        Assert.assertEquals(1, compactNFA.getInitialStates().size());
+        Assert.assertTrue(compactNFA.isAccepting(0));
+        Assert.assertFalse(compactNFA.isAccepting(1));
+        Assert.assertEquals(0, compactNFA.getTransitions(0).size());
+        Assert.assertEquals(0, compactNFA.getTransitions(1).size());
+    }
+}

--- a/util/src/test/java/net/automatalib/util/automaton/random/TabakovVardiRandomAutomataTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/random/TabakovVardiRandomAutomataTest.java
@@ -44,16 +44,16 @@ class TabakovVardiRandomAutomataTest {
             }
         }
         // 5 transitions for 0
-        Assert.assertEquals(compactNFA.getTransitions(0, 0), Set.of(0,3));
+        Assert.assertEquals(compactNFA.getTransitions(0, 0), Set.of(0, 3));
         Assert.assertTrue(compactNFA.getTransitions(1, 0).isEmpty());
-        Assert.assertEquals(compactNFA.getTransitions(2, 0), Set.of(1,2));
+        Assert.assertEquals(compactNFA.getTransitions(2, 0), Set.of(1, 2));
         Assert.assertEquals(compactNFA.getTransitions(3, 0), Set.of(3));
 
         // 5 transitions for 1
         Assert.assertEquals(compactNFA.getTransitions(0, 1), Set.of(3));
         Assert.assertEquals(compactNFA.getTransitions(1, 1), Set.of(1));
         Assert.assertEquals(compactNFA.getTransitions(2, 1), Set.of(0));
-        Assert.assertEquals(compactNFA.getTransitions(3, 1), Set.of(1,2));
+        Assert.assertEquals(compactNFA.getTransitions(3, 1), Set.of(1, 2));
     }
 
     @Test


### PR DESCRIPTION
Add Tabakov-Vardi random automata generator. This method has been used in several papers as an attempt to generate representative NFAs.

Also fix some minor Javadoc typos.