### PR TITLE
Add trim and reverse methods for NFAs

### DIFF
--- a/util/src/main/java/net/automatalib/util/automaton/fsa/NFAs.java
+++ b/util/src/main/java/net/automatalib/util/automaton/fsa/NFAs.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import net.automatalib.alphabet.Alphabet;
 import net.automatalib.automaton.concept.InputAlphabetHolder;
@@ -332,6 +333,35 @@ public final class NFAs {
                                                             A out) {
         return combine(nfa1, nfa2, inputs, out, AcceptanceCombiner.IMPL);
     }
+
+    public static <I> CompactNFA<I> reverse(MutableNFA<Integer, I> nfa, Alphabet<I> inputAlphabet) {
+        CompactNFA<I> result = new CompactNFA<>(inputAlphabet);
+        reverse(nfa, inputAlphabet, result);
+        return result;
+    }
+
+    public static <I> void reverse(MutableNFA<Integer, I> nfa,
+                                            Collection<? extends I> inputs,
+                                            MutableNFA<Integer, I> rNFA) {
+        Set<Integer> initialStates = nfa.getInitialStates();
+
+        // Accepting are initial states and vice versa
+        for(int i: nfa.getStates()) {
+            rNFA.addState(initialStates.contains(i));
+            if (nfa.isAccepting(i)) {
+                rNFA.setInitial(i, true);
+            }
+        }
+        // reverse transitions
+        for(int q: nfa.getStates()) {
+            for(I a: inputs) {
+                for(int s: nfa.getTransitions(q,a)) {
+                    rNFA.addTransition(s, a, q);
+                }
+            }
+        }
+    }
+
 
     /**
      * Determinizes the given NFA, and returns the result as a new complete DFA.

--- a/util/src/main/java/net/automatalib/util/automaton/fsa/NFAs.java
+++ b/util/src/main/java/net/automatalib/util/automaton/fsa/NFAs.java
@@ -334,28 +334,54 @@ public final class NFAs {
         return combine(nfa1, nfa2, inputs, out, AcceptanceCombiner.IMPL);
     }
 
+    /**
+     * Reverse the specified NFA.
+     *
+     * @param nfa
+     *         the original NFA
+     * @param inputAlphabet
+     *         the input alphabet
+     * @param <I>
+     *         input symbol type
+     *
+     * @return the reversed NFA
+     */
     public static <I> CompactNFA<I> reverse(MutableNFA<Integer, I> nfa, Alphabet<I> inputAlphabet) {
         CompactNFA<I> result = new CompactNFA<>(inputAlphabet);
         reverse(nfa, inputAlphabet, result);
         return result;
     }
 
-    public static <I> void reverse(MutableNFA<Integer, I> nfa,
+    /**
+     * Reverse the specified NFA, and stores the result in a given mutable NFA.
+     *
+     * @param nfa
+     *         the original NFA
+     * @param inputs
+     *         the input symbols to consider
+     * @param rNFA
+     *         a mutable NFA for storing the result
+     * @param <I>
+     *         input symbol type
+     * @param <S>
+     *         state type of the automata
+     */
+    public static <I, S> void reverse(MutableNFA<S, I> nfa,
                                             Collection<? extends I> inputs,
-                                            MutableNFA<Integer, I> rNFA) {
-        Set<Integer> initialStates = nfa.getInitialStates();
+                                            MutableNFA<S, I> rNFA) {
+        Set<S> initialStates = nfa.getInitialStates();
 
         // Accepting are initial states and vice versa
-        for(int i: nfa.getStates()) {
+        for(S i: nfa.getStates()) {
             rNFA.addState(initialStates.contains(i));
             if (nfa.isAccepting(i)) {
                 rNFA.setInitial(i, true);
             }
         }
         // reverse transitions
-        for(int q: nfa.getStates()) {
+        for(S q: nfa.getStates()) {
             for(I a: inputs) {
-                for(int s: nfa.getTransitions(q,a)) {
+                for(S s: nfa.getTransitions(q,a)) {
                     rNFA.addTransition(s, a, q);
                 }
             }

--- a/util/src/main/java/net/automatalib/util/automaton/fsa/NFAs.java
+++ b/util/src/main/java/net/automatalib/util/automaton/fsa/NFAs.java
@@ -372,10 +372,10 @@ public final class NFAs {
         Set<S> initialStates = nfa.getInitialStates();
 
         // Accepting are initial states and vice versa
-        for(S i: nfa.getStates()) {
-            rNFA.addState(initialStates.contains(i));
-            if (nfa.isAccepting(i)) {
-                rNFA.setInitial(i, true);
+        for(S q: nfa.getStates()) {
+            rNFA.addState(initialStates.contains(q));
+            if (nfa.isAccepting(q)) {
+                rNFA.setInitial(q, true);
             }
         }
         // reverse transitions
@@ -453,19 +453,19 @@ public final class NFAs {
         }
     }
 
-    static <I> Set<Integer> rightTrimHelper(CompactNFA<I> nfa, Collection<? extends I> inputs) {
-        Set<Integer> found = new HashSet<>();
-        Deque<Integer> stack = new ArrayDeque<>();
+    static <S, I> Set<S> rightTrimHelper(NFA<S, I> nfa, Collection<? extends I> inputs) {
+        Set<S> found = new HashSet<>();
+        Deque<S> stack = new ArrayDeque<>();
 
-        for (Integer init : nfa.getInitialStates()) {
+        for (S init : nfa.getInitialStates()) {
             stack.push(init);
             found.add(init);
         }
 
         while (!stack.isEmpty()) {
-            Integer curr = stack.pop();
+            S curr = stack.pop();
             for (I sym : inputs) {
-                for (Integer succState : nfa.getSuccessors(curr, sym)) {
+                for (S succState : nfa.getSuccessors(curr, sym)) {
                     if (found.add(succState)) {
                         // Add states to stack if they haven't been visited
                         stack.push(succState);

--- a/util/src/main/java/net/automatalib/util/automaton/fsa/NFAs.java
+++ b/util/src/main/java/net/automatalib/util/automaton/fsa/NFAs.java
@@ -19,6 +19,7 @@ import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -374,16 +375,16 @@ public final class NFAs {
         Set<S> initialStates = nfa.getInitialStates();
 
         // Accepting are initial states and vice versa
-        for(S q: nfa.getStates()) {
+        for (S q: nfa.getStates()) {
             rNFA.addState(initialStates.contains(q));
             if (nfa.isAccepting(q)) {
                 rNFA.setInitial(q, true);
             }
         }
         // reverse transitions
-        for(S q: nfa.getStates()) {
-            for(I a: inputs) {
-                for(S s: nfa.getTransitions(q,a)) {
+        for (S q: nfa.getStates()) {
+            for (I a: inputs) {
+                for (S s: nfa.getTransitions(q, a)) {
                     rNFA.addTransition(s, a, q);
                 }
             }
@@ -409,6 +410,7 @@ public final class NFAs {
 
     /**
      * Create a trim (co-accessible) NFA from the specified NFA, and store the result in a given mutable NFA.
+     *
      * @param nfa
      *         the original NFA
      * @param inputAlphabet

--- a/util/src/main/java/net/automatalib/util/automaton/fsa/NFAs.java
+++ b/util/src/main/java/net/automatalib/util/automaton/fsa/NFAs.java
@@ -361,14 +361,16 @@ public final class NFAs {
      *         the input symbols to consider
      * @param rNFA
      *         a mutable NFA for storing the result
-     * @param <I>
-     *         input symbol type
      * @param <S>
      *         state type of the automata
+     * @param <I>
+     *         input symbol type
+     * @param <A>
+     *         reversed NFA type
      */
-    public static <I, S> void reverse(MutableNFA<S, I> nfa,
+    public static <S, I, A extends MutableNFA<S, I>> void reverse(MutableNFA<S, I> nfa,
                                       Collection<? extends I> inputs,
-                                      MutableNFA<S, I> rNFA) {
+                                      A rNFA) {
         Set<S> initialStates = nfa.getInitialStates();
 
         // Accepting are initial states and vice versa
@@ -413,12 +415,17 @@ public final class NFAs {
      *         the input alphabet
      * @param trimNFA
      *         a mutable NFA for storing the result
+     * @param <S>
+     *         state type of the automata
      * @param <I>
      *         input symbol type
+     * @param <A>
+     *         trim NFA type
      */
-    public static <I> void trim(CompactNFA<I> nfa,
+    @SuppressWarnings("unchecked")
+    public static <S, I, A extends MutableNFA<S, I>> void trim(CompactNFA<I> nfa,
                                 Alphabet<I> inputAlphabet,
-                                CompactNFA<I> trimNFA) {
+                                A trimNFA) {
         Set<Integer> coAccessibleStates = new HashSet<>(nfa.size());
         for (int i = 0; i < nfa.size(); i++) {
             coAccessibleStates.add(i);
@@ -430,11 +437,11 @@ public final class NFAs {
 
         // Quotient based upon co-accessible states
         // determine mapping of old states to new ones
-        int[] oldToNewMap = new int[nfa.size()];
+        Object[] oldToNewMap = new Object[nfa.size()];
         // Add new states -- initial, accepting properties
         for (int i = 0; i < nfa.size(); i++) {
             if (coAccessibleStates.contains(i)) {
-                int newState = trimNFA.addState(nfa.isAccepting(i));
+                S newState = trimNFA.addState(nfa.isAccepting(i));
                 oldToNewMap[i] = newState;
                 if (nfa.getInitialStates().contains(i)) {
                     trimNFA.setInitial(newState, true);
@@ -446,7 +453,7 @@ public final class NFAs {
             if (coAccessibleStates.contains(i)) {
                 for(I j: inputAlphabet) {
                     for (int k: nfa.getTransitions(i, j)) {
-                        trimNFA.addTransition(oldToNewMap[i], j, oldToNewMap[k]);
+                        trimNFA.addTransition((S)oldToNewMap[i], j, (S)oldToNewMap[k]);
                     }
                 }
             }

--- a/util/src/main/java/net/automatalib/util/automaton/fsa/NFAs.java
+++ b/util/src/main/java/net/automatalib/util/automaton/fsa/NFAs.java
@@ -392,7 +392,7 @@ public final class NFAs {
     }
 
     /**
-     * Create a trim (co-accessible) NFA from the specified NFA.
+     * Create a trim (accessible and co-accessible) NFA from the specified NFA.
      *
      * @param nfa
      *         the original NFA
@@ -409,7 +409,7 @@ public final class NFAs {
     }
 
     /**
-     * Create a trim (co-accessible) NFA from the specified NFA, and store the result in a given mutable NFA.
+     * Create a trim NFA from the specified NFA, and store the result in a given mutable NFA.
      *
      * @param nfa
      *         the original NFA
@@ -428,21 +428,21 @@ public final class NFAs {
     public static <S, I, A extends MutableNFA<S, I>> void trim(CompactNFA<I> nfa,
                                 Alphabet<I> inputAlphabet,
                                 A trimNFA) {
-        Set<Integer> coAccessibleStates = new HashSet<>(nfa.size());
+        Set<Integer> trimStates = new HashSet<>(nfa.size());
         for (int i = 0; i < nfa.size(); i++) {
-            coAccessibleStates.add(i);
+            trimStates.add(i);
         }
-        // right trim
-        coAccessibleStates.retainAll(rightTrimHelper(nfa, inputAlphabet));
-        // left trim
-        coAccessibleStates.retainAll(rightTrimHelper(reverse(nfa, inputAlphabet), inputAlphabet));
+        // right (accessible) trim
+        trimStates.retainAll(rightTrimHelper(nfa, inputAlphabet));
+        // left (co-accessible) trim
+        trimStates.retainAll(rightTrimHelper(reverse(nfa, inputAlphabet), inputAlphabet));
 
-        // Quotient based upon co-accessible states
+        // Quotient based upon trim states
         // determine mapping of old states to new ones
         Object[] oldToNewMap = new Object[nfa.size()];
         // Add new states -- initial, accepting properties
         for (int i = 0; i < nfa.size(); i++) {
-            if (!coAccessibleStates.contains(i)) {
+            if (!trimStates.contains(i)) {
                 continue;
             }
             S newState = trimNFA.addState(nfa.isAccepting(i));
@@ -451,14 +451,14 @@ public final class NFAs {
                 trimNFA.setInitial(newState, true);
             }
         }
-        // Add transitions to co-accessible states
+        // Add transitions to trim states
         for (int i = 0; i < nfa.size(); i++) {
-            if (!coAccessibleStates.contains(i)) {
+            if (!trimStates.contains(i)) {
                 continue;
             }
             for (I j : inputAlphabet) {
                 for (int k : nfa.getTransitions(i, j)) {
-                    if (coAccessibleStates.contains(k)) {
+                    if (trimStates.contains(k)) {
                         trimNFA.addTransition((S) oldToNewMap[i], j, (S) oldToNewMap[k]);
                     }
                 }

--- a/util/src/main/java/net/automatalib/util/automaton/fsa/NFAs.java
+++ b/util/src/main/java/net/automatalib/util/automaton/fsa/NFAs.java
@@ -440,20 +440,24 @@ public final class NFAs {
         Object[] oldToNewMap = new Object[nfa.size()];
         // Add new states -- initial, accepting properties
         for (int i = 0; i < nfa.size(); i++) {
-            if (coAccessibleStates.contains(i)) {
-                S newState = trimNFA.addState(nfa.isAccepting(i));
-                oldToNewMap[i] = newState;
-                if (nfa.getInitialStates().contains(i)) {
-                    trimNFA.setInitial(newState, true);
-                }
+            if (!coAccessibleStates.contains(i)) {
+                continue;
+            }
+            S newState = trimNFA.addState(nfa.isAccepting(i));
+            oldToNewMap[i] = newState;
+            if (nfa.getInitialStates().contains(i)) {
+                trimNFA.setInitial(newState, true);
             }
         }
-        // Add transitions
+        // Add transitions to co-accessible states
         for (int i = 0; i < nfa.size(); i++) {
-            if (coAccessibleStates.contains(i)) {
-                for(I j: inputAlphabet) {
-                    for (int k: nfa.getTransitions(i, j)) {
-                        trimNFA.addTransition((S)oldToNewMap[i], j, (S)oldToNewMap[k]);
+            if (!coAccessibleStates.contains(i)) {
+                continue;
+            }
+            for (I j : inputAlphabet) {
+                for (int k : nfa.getTransitions(i, j)) {
+                    if (coAccessibleStates.contains(k)) {
+                        trimNFA.addTransition((S) oldToNewMap[i], j, (S) oldToNewMap[k]);
                     }
                 }
             }

--- a/util/src/test/java/net/automatalib/util/automaton/fsa/DFAsTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/fsa/DFAsTest.java
@@ -117,6 +117,30 @@ public class DFAsTest {
     }
 
     @Test
+    public void testTrim() {
+        Alphabet<Integer> alphabet = Alphabets.singleton(0);
+        CompactDFA<Integer> dfa = new CompactDFA<>(alphabet);
+
+        int q0 = dfa.addInitialState(false);
+
+        // with no accepting states if trimmed this will have no states
+        Assert.assertEquals(DFAs.trim(dfa, alphabet).size(), 0);
+
+        // accepting state is not accessible
+        int q1 = dfa.addState(true);
+        Assert.assertEquals(DFAs.trim(dfa, alphabet).size(), 0);
+
+        // accessible and co-accessible
+        dfa.addTransition(q0, 0, q1);
+        Assert.assertEquals(DFAs.trim(dfa, alphabet).size(), 2);
+
+        // dead-end is not co-accessible
+        int q2 = dfa.addState(false);
+        dfa.addTransition(q1, 0, q2);
+        Assert.assertEquals(DFAs.trim(dfa, alphabet).size(), 2);
+    }
+
+    @Test
     public void testComplement() {
         DFA<?, Integer> expected = forVector(VECTOR_1_NEG);
         DFA<?, Integer> actual = DFAs.complement(testDfa1, testAlphabet);

--- a/util/src/test/java/net/automatalib/util/automaton/fsa/NFAsTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/fsa/NFAsTest.java
@@ -145,8 +145,39 @@ public class NFAsTest {
 
     @Test
     public void testTrim() {
-        CompactNFA<Integer> trimNFA = NFAs.trim(testNfa1, testAlphabet);
-        assertEquivalence(testNfa1, trimNFA, testAlphabet);
+        // Test trim equivalence of testNfa1, and its reverse
+        assertEquivalence(testNfa1, NFAs.trim(testNfa1, testAlphabet), testAlphabet);
+        CompactNFA<Integer> reverseNFA = NFAs.reverse(testNfa1, testAlphabet);
+        assertEquivalence(reverseNFA, NFAs.trim(reverseNFA, testAlphabet), testAlphabet);
+
+        Alphabet<Integer> alphabet = Alphabets.integers(0, 1);
+        CompactNFA<Integer> nfa = new CompactNFA<>(alphabet);
+        int q0 = nfa.addInitialState(false);
+        // With no accepting states, if trimmed this will have no states
+        Assert.assertEquals(NFAs.trim(nfa, alphabet).size(), 0);
+
+        // Accepting state is not reachable
+        int q1 = nfa.addState(true);
+        Assert.assertEquals(NFAs.trim(nfa, alphabet).size(), 0);
+
+        // Co-accessible
+        nfa.addTransition(q0, 0, q1);
+        Assert.assertEquals(NFAs.trim(nfa, alphabet).size(), 2);
+
+        nfa.clear();
+        q0 = nfa.addInitialState(false);
+        q1 = nfa.addState(false);
+        int q2 = nfa.addState(true);
+        nfa.addTransition(q0, 0, q1);
+        nfa.addTransition(q0, 0, q2);
+
+        // Accessible but not co-accessible
+        Set<Integer> actual = NFAs.rightTrimHelper(nfa, alphabet);
+        Assert.assertEquals(actual, Set.of(0, 1, 2));
+        actual = NFAs.rightTrimHelper(NFAs.reverse(nfa, alphabet), alphabet);
+        Assert.assertEquals(actual, Set.of(0,2));
+
+        Assert.assertEquals(NFAs.trim(nfa, alphabet).size(), 2);
     }
 
     @Test

--- a/util/src/test/java/net/automatalib/util/automaton/fsa/NFAsTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/fsa/NFAsTest.java
@@ -144,6 +144,12 @@ public class NFAsTest {
     }
 
     @Test
+    public void testTrim() {
+        CompactNFA<Integer> trimNFA = NFAs.trim(testNfa1, testAlphabet);
+        assertEquivalence(testNfa1, trimNFA, testAlphabet);
+    }
+
+    @Test
     public void testDeterminizeDFA() {
         determinizeDFA(new CompactDFA.Creator<>());
         determinizeDFA(FastDFA::new);

--- a/util/src/test/java/net/automatalib/util/automaton/fsa/NFAsTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/fsa/NFAsTest.java
@@ -15,7 +15,6 @@
  */
 package net.automatalib.util.automaton.fsa;
 
-
 import java.util.Random;
 import java.util.Set;
 

--- a/util/src/test/java/net/automatalib/util/automaton/fsa/NFAsTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/fsa/NFAsTest.java
@@ -15,7 +15,9 @@
  */
 package net.automatalib.util.automaton.fsa;
 
+
 import java.util.Random;
+import java.util.Set;
 
 import net.automatalib.alphabet.Alphabet;
 import net.automatalib.alphabet.impl.Alphabets;
@@ -35,9 +37,6 @@ import net.automatalib.util.ts.acceptor.AcceptanceCombiner;
 import net.automatalib.word.Word;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.util.Collections;
-import java.util.Set;
 
 public class NFAsTest {
 
@@ -132,12 +131,12 @@ public class NFAsTest {
     public void testReverse() {
         CompactNFA<Integer> rNFA = NFAs.reverse(testNfa1, testAlphabet);
         Assert.assertEquals(rNFA.size(), testNfa1.size());
-        for(int i=0;i<rNFA.size();i++) {
+        for (int i=0; i<rNFA.size(); i++) {
             Assert.assertEquals(rNFA.isAccepting(i), i == 0);
             int iMinusOneModSize = (rNFA.size() + i - 1) % rNFA.size();
             Assert.assertEquals(rNFA.getTransitions(i), Set.of(iMinusOneModSize));
         }
-        Assert.assertEquals(rNFA.getInitialStates(), Set.of(0,1));
+        Assert.assertEquals(rNFA.getInitialStates(), Set.of(0, 1));
 
         // double-reverse == no reverse
         assertEquivalence(testNfa1, NFAs.reverse(rNFA, testAlphabet), testAlphabet);
@@ -150,9 +149,10 @@ public class NFAsTest {
         CompactNFA<Integer> reverseNFA = NFAs.reverse(testNfa1, testAlphabet);
         assertEquivalence(reverseNFA, NFAs.trim(reverseNFA, testAlphabet), testAlphabet);
 
-        Alphabet<Integer> alphabet = Alphabets.integers(0, 1);
+        Alphabet<Integer> alphabet = Alphabets.integers(0, 0);
         CompactNFA<Integer> nfa = new CompactNFA<>(alphabet);
         int q0 = nfa.addInitialState(false);
+
         // With no accepting states, if trimmed this will have no states
         Assert.assertEquals(NFAs.trim(nfa, alphabet).size(), 0);
 
@@ -164,19 +164,17 @@ public class NFAsTest {
         nfa.addTransition(q0, 0, q1);
         Assert.assertEquals(NFAs.trim(nfa, alphabet).size(), 2);
 
+        // q0 -> q1, q1 -> q2: accessible but not co-accessible
         nfa.clear();
         q0 = nfa.addInitialState(false);
         q1 = nfa.addState(false);
         int q2 = nfa.addState(true);
         nfa.addTransition(q0, 0, q1);
         nfa.addTransition(q0, 0, q2);
-
-        // Accessible but not co-accessible
         Set<Integer> actual = NFAs.rightTrimHelper(nfa, alphabet);
         Assert.assertEquals(actual, Set.of(0, 1, 2));
         actual = NFAs.rightTrimHelper(NFAs.reverse(nfa, alphabet), alphabet);
-        Assert.assertEquals(actual, Set.of(0,2));
-
+        Assert.assertEquals(actual, Set.of(0, 2));
         Assert.assertEquals(NFAs.trim(nfa, alphabet).size(), 2);
     }
 

--- a/util/src/test/java/net/automatalib/util/automaton/fsa/NFAsTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/fsa/NFAsTest.java
@@ -36,6 +36,9 @@ import net.automatalib.word.Word;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+import java.util.Set;
+
 public class NFAsTest {
 
     private static final boolean[] VECTOR_1 = {true, true, false, false};
@@ -123,6 +126,21 @@ public class NFAsTest {
         NFA<?, Integer> actual = NFAs.impl(testNfa1, testNfa2, testAlphabet);
 
         assertEquivalence(actual, expected, testAlphabet);
+    }
+
+    @Test
+    public void testReverse() {
+        CompactNFA<Integer> rNFA = NFAs.reverse(testNfa1, testAlphabet);
+        Assert.assertEquals(rNFA.size(), testNfa1.size());
+        for(int i=0;i<rNFA.size();i++) {
+            Assert.assertEquals(rNFA.isAccepting(i), i == 0);
+            int iMinusOneModSize = (rNFA.size() + i - 1) % rNFA.size();
+            Assert.assertEquals(rNFA.getTransitions(i), Set.of(iMinusOneModSize));
+        }
+        Assert.assertEquals(rNFA.getInitialStates(), Set.of(0,1));
+
+        // double-reverse == no reverse
+        assertEquivalence(testNfa1, NFAs.reverse(rNFA, testAlphabet), testAlphabet);
     }
 
     @Test

--- a/util/src/test/java/net/automatalib/util/automaton/fsa/NFAsTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/fsa/NFAsTest.java
@@ -156,11 +156,11 @@ public class NFAsTest {
         // With no accepting states, if trimmed this will have no states
         Assert.assertEquals(NFAs.trim(nfa, alphabet).size(), 0);
 
-        // Accepting state is not reachable
+        // Accepting state is not accessible
         int q1 = nfa.addState(true);
         Assert.assertEquals(NFAs.trim(nfa, alphabet).size(), 0);
 
-        // Co-accessible
+        // Accessible and co-accessible
         nfa.addTransition(q0, 0, q1);
         Assert.assertEquals(NFAs.trim(nfa, alphabet).size(), 2);
 


### PR DESCRIPTION
Add trim and reverse methods for NFAs. (Reverse could be useful in theory for DFAs to NFAs, as well.)

I tried to make these generic, but got stuck in basically the same place as before.