### PR TITLE
Bump minimal Java version to 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 * AutomataLib now requires Java 11 at runtime.
 
+### Removed
+
+* `IOUtil#copy(Reader, Writer)` has been removed. Use `Reader#transferTo(Writer)` instead.
+
 
 ## [0.12.1] - 2025-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 [Full changelog](https://github.com/LearnLib/automatalib/compare/automatalib-0.12.1...HEAD)
 
+### Changed
+
+* AutomataLib now requires Java 11 at runtime.
+
 
 ## [0.12.1] - 2025-03-11
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Contributions -- whether it is in the form of new features, better documentation
 
 For simply using AutomataLib you may use the Maven artifacts which are available in the [Maven Central repository][maven-central].
 It is also possible to download a bundled [distribution artifact][maven-central-distr] if you want to use AutomataLib without Maven support.
-Note that AutomataLib requires Java 11 (or newer) to build but still supports Java 8 at runtime.
+Note that AutomataLib requires Java 11 (or newer) to build and run.
 
 #### Building development versions
 

--- a/adapters/brics/pom.xml
+++ b/adapters/brics/pom.xml
@@ -92,6 +92,18 @@ limitations under the License.
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!-- The plugin doesn't like dependencies with missing module names so build with JPMS disabled -->
+                    <legacyMode>true</legacyMode>
+                    <disableSourcepathUsage>true</disableSourcepathUsage>
+                    <sourceFileExcludes>
+                        <sourceFileExclude>**\/module-info.java</sourceFileExclude>
+                    </sourceFileExcludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/api/src/main/java/net/automatalib/automaton/vpa/SEVPAGraphView.java
+++ b/api/src/main/java/net/automatalib/automaton/vpa/SEVPAGraphView.java
@@ -88,7 +88,7 @@ public class SEVPAGraphView<L, I> implements Graph<L, SevpaViewEdge<L, I>> {
 
     @Override
     public VisualizationHelper<L, SevpaViewEdge<L, I>> getVisualizationHelper() {
-        return new DefaultVisualizationHelper<L, SevpaViewEdge<L, I>>() {
+        return new DefaultVisualizationHelper<>() {
 
             @Override
             protected Collection<L> initialNodes() {

--- a/api/src/main/java/net/automatalib/graph/ads/RecursiveADSNode.java
+++ b/api/src/main/java/net/automatalib/graph/ads/RecursiveADSNode.java
@@ -132,7 +132,7 @@ public interface RecursiveADSNode<S, I, O, N extends RecursiveADSNode<S, I, O, N
 
     @Override
     default VisualizationHelper<N, N> getVisualizationHelper() {
-        return new VisualizationHelper<N, N>() {
+        return new VisualizationHelper<>() {
 
             @Override
             public boolean getNodeProperties(N node, Map<String, String> properties) {

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -236,12 +236,7 @@ limitations under the License.
                                     <failOnWarning>true</failOnWarning>
                                     <fork>true</fork>
                                     <outputDirectory>${project.build.directory}/checkerframework</outputDirectory>
-                                    <annotationProcessorPaths>
-                                        <path>
-                                            <groupId>de.learnlib.tooling</groupId>
-                                            <artifactId>processors</artifactId>
-                                            <version>${build-tools.version}</version>
-                                        </path>
+                                    <annotationProcessorPaths combine.children="append">
                                         <path>
                                             <groupId>org.checkerframework</groupId>
                                             <artifactId>checker</artifactId>
@@ -249,10 +244,9 @@ limitations under the License.
                                         </path>
                                     </annotationProcessorPaths>
                                     <annotationProcessors>
-                                        <annotationProcessor>de.learnlib.tooling.processor.builder.BuilderProcessor</annotationProcessor>
-                                        <annotationProcessor>de.learnlib.tooling.processor.edsl.EDSLProcessor</annotationProcessor>
-                                        <annotationProcessor>de.learnlib.tooling.processor.refinement.RefinementProcessor</annotationProcessor>
                                         <annotationProcessor>org.checkerframework.checker.nullness.NullnessChecker</annotationProcessor>
+                                        <!-- by having to explicitly list the CF checkers, we also need to list otherwise automatically picked-up processors -->
+                                        <annotationProcessor>de.learnlib.tooling.processor.edsl.EDSLProcessor</annotationProcessor>
                                     </annotationProcessors>
                                     <compilerArgs>
                                         <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
@@ -286,12 +280,7 @@ limitations under the License.
                                     <failOnWarning>true</failOnWarning>
                                     <fork>true</fork>
                                     <outputDirectory>${project.build.directory}/checkerframework</outputDirectory>
-                                    <annotationProcessorPaths>
-                                        <path>
-                                            <groupId>de.learnlib.tooling</groupId>
-                                            <artifactId>processors</artifactId>
-                                            <version>${build-tools.version}</version>
-                                        </path>
+                                    <annotationProcessorPaths combine.children="append">
                                         <path>
                                             <groupId>org.checkerframework</groupId>
                                             <artifactId>checker</artifactId>
@@ -299,9 +288,6 @@ limitations under the License.
                                         </path>
                                     </annotationProcessorPaths>
                                     <annotationProcessors>
-                                        <annotationProcessor>de.learnlib.tooling.processor.builder.BuilderProcessor</annotationProcessor>
-                                        <annotationProcessor>de.learnlib.tooling.processor.edsl.EDSLProcessor</annotationProcessor>
-                                        <annotationProcessor>de.learnlib.tooling.processor.refinement.RefinementProcessor</annotationProcessor>
                                         <annotationProcessor>org.checkerframework.checker.nullness.NullnessChecker</annotationProcessor>
                                     </annotationProcessors>
                                     <compilerArgs>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -233,17 +233,15 @@ limitations under the License.
                                     <goal>compile</goal>
                                 </goals>
                                 <configuration>
-                                    <release>11</release>
                                     <failOnWarning>true</failOnWarning>
                                     <fork>true</fork>
-                                    <!--
-                                     Setting a different output directly can fail the build when using other annotation
-                                     processors as well. However, with using the same output directory, we pack Java 11
-                                     code in the jars which will fail other analysis tools. Currently, checkerframework
-                                     cannot be run with our other analysis steps...
-                                     -->
-                                    <!--outputDirectory>${project.build.directory}/checkerframework</outputDirectory-->
+                                    <outputDirectory>${project.build.directory}/checkerframework</outputDirectory>
                                     <annotationProcessorPaths>
+                                        <path>
+                                            <groupId>de.learnlib.tooling</groupId>
+                                            <artifactId>processors</artifactId>
+                                            <version>${build-tools.version}</version>
+                                        </path>
                                         <path>
                                             <groupId>org.checkerframework</groupId>
                                             <artifactId>checker</artifactId>
@@ -251,6 +249,9 @@ limitations under the License.
                                         </path>
                                     </annotationProcessorPaths>
                                     <annotationProcessors>
+                                        <annotationProcessor>de.learnlib.tooling.processor.builder.BuilderProcessor</annotationProcessor>
+                                        <annotationProcessor>de.learnlib.tooling.processor.edsl.EDSLProcessor</annotationProcessor>
+                                        <annotationProcessor>de.learnlib.tooling.processor.refinement.RefinementProcessor</annotationProcessor>
                                         <annotationProcessor>org.checkerframework.checker.nullness.NullnessChecker</annotationProcessor>
                                     </annotationProcessors>
                                     <compilerArgs>
@@ -284,14 +285,13 @@ limitations under the License.
                                 <configuration>
                                     <failOnWarning>true</failOnWarning>
                                     <fork>true</fork>
-                                    <!--
-                                     Setting a different output directly can fail the build when using other annotation
-                                     processors as well. However, with using the same output directory, we pack Java 11
-                                     code in the jars which will fail other analysis tools. Currently, checkerframework
-                                     cannot be run with our other analysis steps...
-                                     -->
-                                    <!--outputDirectory>${project.build.directory}/checkerframework</outputDirectory-->
+                                    <outputDirectory>${project.build.directory}/checkerframework</outputDirectory>
                                     <annotationProcessorPaths>
+                                        <path>
+                                            <groupId>de.learnlib.tooling</groupId>
+                                            <artifactId>processors</artifactId>
+                                            <version>${build-tools.version}</version>
+                                        </path>
                                         <path>
                                             <groupId>org.checkerframework</groupId>
                                             <artifactId>checker</artifactId>
@@ -299,6 +299,9 @@ limitations under the License.
                                         </path>
                                     </annotationProcessorPaths>
                                     <annotationProcessors>
+                                        <annotationProcessor>de.learnlib.tooling.processor.builder.BuilderProcessor</annotationProcessor>
+                                        <annotationProcessor>de.learnlib.tooling.processor.edsl.EDSLProcessor</annotationProcessor>
+                                        <annotationProcessor>de.learnlib.tooling.processor.refinement.RefinementProcessor</annotationProcessor>
                                         <annotationProcessor>org.checkerframework.checker.nullness.NullnessChecker</annotationProcessor>
                                     </annotationProcessors>
                                     <compilerArgs>

--- a/commons/util/src/main/java/net/automatalib/common/util/IOUtil.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/IOUtil.java
@@ -313,11 +313,7 @@ public final class IOUtil {
      *         if reading from or writing to the respective reader / writer throws this exception
      */
     public static void copy(Reader in, Writer out) throws IOException {
-        final char[] buf = new char[DEFAULT_BUFFER_SIZE];
-        int read;
-        while ((read = in.read(buf)) >= 0) {
-            out.write(buf, 0, read);
-        }
+        in.transferTo(out);
     }
 
     /**

--- a/commons/util/src/main/java/net/automatalib/common/util/IOUtil.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/IOUtil.java
@@ -302,21 +302,6 @@ public final class IOUtil {
     }
 
     /**
-     * Copies the contents of the given reader into the given writer.
-     *
-     * @param in
-     *         the reader to read data from
-     * @param out
-     *         the writer to write data to
-     *
-     * @throws IOException
-     *         if reading from or writing to the respective reader / writer throws this exception
-     */
-    public static void copy(Reader in, Writer out) throws IOException {
-        in.transferTo(out);
-    }
-
-    /**
      * Reads the data from the given reader and returns its contents as a string.
      *
      * @param r
@@ -329,7 +314,7 @@ public final class IOUtil {
      */
     public static String toString(Reader r) throws IOException {
         final StringWriter w = new StringWriter();
-        copy(r, w);
+        r.transferTo(w);
         return w.toString();
     }
 }

--- a/commons/util/src/main/java/net/automatalib/common/util/collection/IteratorUtil.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/collection/IteratorUtil.java
@@ -224,7 +224,7 @@ public final class IteratorUtil {
      * @return the iterator
      */
     public static <T> Iterator<T> singleton(T element) {
-        return new Iterator<T>() {
+        return new Iterator<>() {
 
             private boolean hasNext = true;
 

--- a/commons/util/src/main/java/net/automatalib/common/util/nid/DynamicList.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/nid/DynamicList.java
@@ -140,7 +140,7 @@ public class DynamicList<T extends MutableNumericID> extends AbstractList<T> {
 
     @Override
     public Iterator<T> iterator() {
-        return new Iterator<T>() {
+        return new Iterator<>() {
 
             int index;
 

--- a/commons/util/src/main/java/net/automatalib/common/util/process/ProcessUtil.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/process/ProcessUtil.java
@@ -285,7 +285,7 @@ public final class ProcessUtil {
         if (input != null) {
             try (OutputStream processInput = process.getOutputStream();
                  Writer writer = IOUtil.asBufferedUTF8Writer(processInput)) {
-                IOUtil.copy(input, writer);
+                input.transferTo(writer);
             }
         }
     }

--- a/core/src/main/java/net/automatalib/alphabet/impl/AbstractAlphabet.java
+++ b/core/src/main/java/net/automatalib/alphabet/impl/AbstractAlphabet.java
@@ -32,7 +32,7 @@ public abstract class AbstractAlphabet<I> extends AbstractList<I> implements Alp
      */
     @Override
     public AbstractAlphabet<I> reversed() {
-        return new AbstractAlphabet<I>() {
+        return new AbstractAlphabet<>() {
 
             @Override
             public boolean containsSymbol(I symbol) {

--- a/core/src/main/java/net/automatalib/alphabet/impl/FastAlphabet.java
+++ b/core/src/main/java/net/automatalib/alphabet/impl/FastAlphabet.java
@@ -78,7 +78,7 @@ public class FastAlphabet<I extends MutableNumericID> extends DynamicList<I> imp
      */
     @Override
     public FastAlphabet<I> reversed() {
-        return new FastAlphabet<I>() {
+        return new FastAlphabet<>() {
 
             @Override
             public boolean containsSymbol(I symbol) {

--- a/core/src/main/java/net/automatalib/automaton/base/AbstractCompact.java
+++ b/core/src/main/java/net/automatalib/automaton/base/AbstractCompact.java
@@ -279,11 +279,7 @@ public abstract class AbstractCompact<I, T, SP, TP> implements MutableAutomaton<
     protected final @Nullable Object[] updateTransitionStorage(@Nullable Object[] oldStorage,
                                                                @Nullable Object defaultValue,
                                                                Payload payload) {
-        // explicit generic declaration required for checkerframework
-        return payload.type.<@Nullable Object[]>updateStorage(oldStorage,
-                                                              payload,
-                                                              (IntFunction<@Nullable Object[]>) Object[]::new,
-                                                              (arr, idx) -> arr[idx] = defaultValue);
+        return payload.type.updateStorage(oldStorage, payload, Object[]::new, (arr, idx) -> arr[idx] = defaultValue);
     }
 
     /**

--- a/core/src/main/java/net/automatalib/graph/impl/CompactPMPG.java
+++ b/core/src/main/java/net/automatalib/graph/impl/CompactPMPG.java
@@ -16,6 +16,7 @@
 package net.automatalib.graph.impl;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 
 import net.automatalib.common.util.array.ArrayStorage;
@@ -42,20 +43,12 @@ public class CompactPMPG<L, AP>
 
     @Override
     public void setInitialNode(@Nullable Integer initialNode) {
-        if (initialNode == null) {
-            this.initialNode = -1;
-        } else {
-            this.initialNode = initialNode;
-        }
+        this.initialNode = Objects.requireNonNullElse(initialNode, -1);
     }
 
     @Override
     public void setFinalNode(@Nullable Integer finalNode) {
-        if (finalNode == null) {
-            this.finalNode = -1;
-        } else {
-            this.finalNode = finalNode;
-        }
+        this.finalNode = Objects.requireNonNullElse(finalNode, -1);
     }
 
     @Override

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -428,6 +428,12 @@ limitations under the License.
                             <finalName>automatalib-${project.version}</finalName>
                             <jarOutputDirectory>${project.build.directory}/bundles</jarOutputDirectory>
                             <includeDependencySources>true</includeDependencySources>
+                            <!-- The plugin doesn't like dependencies with missing module names so build with JPMS disabled -->
+                            <legacyMode>true</legacyMode>
+                            <disableSourcepathUsage>true</disableSourcepathUsage>
+                            <sourceFileExcludes>
+                                <sourceFileExclude>**\/module-info.java</sourceFileExclude>
+                            </sourceFileExcludes>
                             <dependencySourceIncludes>
                                 <dependencySourceInclude>net.automatalib:*</dependencySourceInclude>
                             </dependencySourceIncludes>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -428,7 +428,7 @@ limitations under the License.
                             <finalName>automatalib-${project.version}</finalName>
                             <jarOutputDirectory>${project.build.directory}/bundles</jarOutputDirectory>
                             <includeDependencySources>true</includeDependencySources>
-                            <!-- The plugin doesn't like dependencies with missing module names so build with JPMS disabled -->
+                            <!-- Aggregating multiple (sometimes even missing) module-info,javas causes problems -->
                             <legacyMode>true</legacyMode>
                             <disableSourcepathUsage>true</disableSourcepathUsage>
                             <sourceFileExcludes>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -428,7 +428,7 @@ limitations under the License.
                             <finalName>automatalib-${project.version}</finalName>
                             <jarOutputDirectory>${project.build.directory}/bundles</jarOutputDirectory>
                             <includeDependencySources>true</includeDependencySources>
-                            <!-- Aggregating multiple (sometimes even missing) module-info,javas causes problems -->
+                            <!-- Aggregating multiple (sometimes even missing) module-info.javas causes problems -->
                             <legacyMode>true</legacyMode>
                             <disableSourcepathUsage>true</disableSourcepathUsage>
                             <sourceFileExcludes>

--- a/incremental/src/main/java/net/automatalib/incremental/dfa/dag/AbstractIncrementalDFADAGBuilder.java
+++ b/incremental/src/main/java/net/automatalib/incremental/dfa/dag/AbstractIncrementalDFADAGBuilder.java
@@ -478,12 +478,11 @@ abstract class AbstractIncrementalDFADAGBuilder<I> extends AbstractIncrementalDF
 
     @Override
     public Graph<?, ?> asGraph() {
-        return new UniversalAutomatonGraphView<State, I, State, Acceptance, Void, TransitionSystemView>(new TransitionSystemView(),
-                                                                                                        inputAlphabet) {
+        return new UniversalAutomatonGraphView<>(new TransitionSystemView(), inputAlphabet) {
 
             @Override
             public VisualizationHelper<State, TransitionEdge<I, State>> getVisualizationHelper() {
-                return new AbstractVisualizationHelper<State, I, State, TransitionSystemView>(automaton) {
+                return new AbstractVisualizationHelper<>(automaton) {
 
                     @Override
                     public boolean getNodeProperties(State node, Map<String, String> properties) {

--- a/incremental/src/main/java/net/automatalib/incremental/dfa/tree/IncrementalDFATreeBuilder.java
+++ b/incremental/src/main/java/net/automatalib/incremental/dfa/tree/IncrementalDFATreeBuilder.java
@@ -195,12 +195,11 @@ public class IncrementalDFATreeBuilder<I> extends AbstractIncrementalDFABuilder<
 
     @Override
     public Graph<?, ?> asGraph() {
-        return new UniversalAutomatonGraphView<Node, I, Node, Acceptance, Void, TransitionSystemView>(new TransitionSystemView(),
-                                                                                                      inputAlphabet) {
+        return new UniversalAutomatonGraphView<>(new TransitionSystemView(), inputAlphabet) {
 
             @Override
             public VisualizationHelper<Node, TransitionEdge<I, Node>> getVisualizationHelper() {
-                return new AbstractVisualizationHelper<Node, I, Node, TransitionSystemView>(automaton) {
+                return new AbstractVisualizationHelper<>(automaton) {
 
                     @Override
                     public Acceptance getAcceptance(Node node) {

--- a/incremental/src/main/java/net/automatalib/incremental/dfa/tree/IncrementalPCDFATreeBuilder.java
+++ b/incremental/src/main/java/net/automatalib/incremental/dfa/tree/IncrementalPCDFATreeBuilder.java
@@ -174,12 +174,11 @@ public class IncrementalPCDFATreeBuilder<I> extends IncrementalDFATreeBuilder<I>
 
     @Override
     public Graph<?, ?> asGraph() {
-        return new UniversalAutomatonGraphView<Node, I, Node, Acceptance, Void, TransitionSystemView>(new TransitionSystemView(),
-                                                                                                      inputAlphabet) {
+        return new UniversalAutomatonGraphView<>(new TransitionSystemView(), inputAlphabet) {
 
             @Override
             public VisualizationHelper<Node, TransitionEdge<I, Node>> getVisualizationHelper() {
-                return new AbstractVisualizationHelper<Node, I, Node, TransitionSystemView>(automaton) {
+                return new AbstractVisualizationHelper<>(automaton) {
 
                     @Override
                     public Acceptance getAcceptance(Node node) {

--- a/incremental/src/main/java/net/automatalib/incremental/mealy/dag/IncrementalMealyDAGBuilder.java
+++ b/incremental/src/main/java/net/automatalib/incremental/mealy/dag/IncrementalMealyDAGBuilder.java
@@ -568,11 +568,11 @@ public class IncrementalMealyDAGBuilder<I, O> implements IncrementalMealyBuilder
 
     @Override
     public Graph<?, ?> asGraph() {
-        return new MealyGraphView<State<O>, I, Transition<O>, O, AutomatonView>(new AutomatonView(), inputAlphabet) {
+        return new MealyGraphView<>(new AutomatonView(), inputAlphabet) {
 
             @Override
             public VisualizationHelper<State<O>, TransitionEdge<I, Transition<O>>> getVisualizationHelper() {
-                return new net.automatalib.incremental.mealy.VisualizationHelper<State<O>, I, Transition<O>, O>(this.automaton) {
+                return new net.automatalib.incremental.mealy.VisualizationHelper<>(this.automaton) {
 
                     @Override
                     public boolean getNodeProperties(State<O> node, Map<String, String> properties) {

--- a/incremental/src/main/java/net/automatalib/incremental/mealy/tree/AbstractAlphabetBasedMealyTreeBuilder.java
+++ b/incremental/src/main/java/net/automatalib/incremental/mealy/tree/AbstractAlphabetBasedMealyTreeBuilder.java
@@ -91,8 +91,7 @@ abstract class AbstractAlphabetBasedMealyTreeBuilder<I, O> extends AbstractMealy
 
     @Override
     public Graph<Node<O>, ?> asGraph() {
-        return new MealyGraphView<Node<O>, I, Edge<Node<O>, O>, O, MealyMachineView>(new MealyMachineView(),
-                                                                                     inputAlphabet) {
+        return new MealyGraphView<>(new MealyMachineView(), inputAlphabet) {
             @Override
             public VisualizationHelper<Node<O>, TransitionEdge<I, Edge<Node<O>, O>>> getVisualizationHelper() {
                 return new net.automatalib.incremental.mealy.VisualizationHelper<>(automaton);

--- a/incremental/src/main/java/net/automatalib/incremental/mealy/tree/DynamicIncrementalMealyTreeBuilder.java
+++ b/incremental/src/main/java/net/automatalib/incremental/mealy/tree/DynamicIncrementalMealyTreeBuilder.java
@@ -128,7 +128,7 @@ public class DynamicIncrementalMealyTreeBuilder<I, O> extends AbstractMealyTreeB
 
         @Override
         public VisualizationHelper<DynamicNode<I, O>, Entry<I, Edge<DynamicNode<I, O>, O>>> getVisualizationHelper() {
-            return new DefaultVisualizationHelper<DynamicNode<I, O>, Entry<I, Edge<DynamicNode<I, O>, O>>>() {
+            return new DefaultVisualizationHelper<>() {
 
                 private int id;
 

--- a/incremental/src/main/java/net/automatalib/incremental/moore/dag/IncrementalMooreDAGBuilder.java
+++ b/incremental/src/main/java/net/automatalib/incremental/moore/dag/IncrementalMooreDAGBuilder.java
@@ -589,11 +589,11 @@ public class IncrementalMooreDAGBuilder<I, O> implements IncrementalMooreBuilder
 
     @Override
     public Graph<?, ?> asGraph() {
-        return new MooreGraphView<State<O>, I, State<O>, O, AutomatonView>(new AutomatonView(), inputAlphabet) {
+        return new MooreGraphView<>(new AutomatonView(), inputAlphabet) {
 
             @Override
             public VisualizationHelper<State<O>, TransitionEdge<I, State<O>>> getVisualizationHelper() {
-                return new MooreVisualizationHelper<State<O>, I, State<O>, O>(automaton) {
+                return new MooreVisualizationHelper<>(automaton) {
 
                     @Override
                     public boolean getNodeProperties(State<O> node, Map<String, String> properties) {

--- a/incremental/src/main/java/net/automatalib/incremental/moore/tree/IncrementalMooreTreeBuilder.java
+++ b/incremental/src/main/java/net/automatalib/incremental/moore/tree/IncrementalMooreTreeBuilder.java
@@ -207,11 +207,11 @@ public class IncrementalMooreTreeBuilder<I, O> implements IncrementalMooreBuilde
 
     @Override
     public Graph<?, ?> asGraph() {
-        return new MooreGraphView<Node<O>, I, Node<O>, O, TransitionSystemView>(new TransitionSystemView(), alphabet) {
+        return new MooreGraphView<>(new TransitionSystemView(), alphabet) {
 
             @Override
             public VisualizationHelper<Node<O>, TransitionEdge<I, Node<O>>> getVisualizationHelper() {
-                return new MooreVisualizationHelper<Node<O>, I, Node<O>, O>(automaton) {
+                return new MooreVisualizationHelper<>(automaton) {
 
                     @Override
                     public boolean getNodeProperties(Node<O> node, Map<String, String> properties) {

--- a/incremental/src/test/java/net/automatalib/incremental/dfa/AbstractIncrementalDFABuilderTest.java
+++ b/incremental/src/test/java/net/automatalib/incremental/dfa/AbstractIncrementalDFABuilderTest.java
@@ -176,7 +176,7 @@ public abstract class AbstractIncrementalDFABuilderTest {
                 getDOTResource()))) {
 
             GraphDOT.write(incDfa.asGraph(), dotWriter);
-            IOUtil.copy(reader, expectedWriter);
+            reader.transferTo(expectedWriter);
 
             Assert.assertEquals(dotWriter.toString(), expectedWriter.toString());
         }

--- a/incremental/src/test/java/net/automatalib/incremental/dfa/AbstractIncrementalPCDFABuilderTest.java
+++ b/incremental/src/test/java/net/automatalib/incremental/dfa/AbstractIncrementalPCDFABuilderTest.java
@@ -174,7 +174,7 @@ public abstract class AbstractIncrementalPCDFABuilderTest {
                 getDOTResource()))) {
 
             GraphDOT.write(incPcDfa.asGraph(), dotWriter);
-            IOUtil.copy(reader, expectedWriter);
+            reader.transferTo(expectedWriter);
 
             Assert.assertEquals(dotWriter.toString(), expectedWriter.toString());
         }

--- a/incremental/src/test/java/net/automatalib/incremental/mealy/AbstractIncrementalMealyBuilderTest.java
+++ b/incremental/src/test/java/net/automatalib/incremental/mealy/AbstractIncrementalMealyBuilderTest.java
@@ -193,7 +193,7 @@ public abstract class AbstractIncrementalMealyBuilderTest {
                 getDOTResource()))) {
 
             GraphDOT.write(incMealy.asGraph(), dotWriter);
-            IOUtil.copy(reader, expectedWriter);
+            reader.transferTo(expectedWriter);
 
             Assert.assertEquals(dotWriter.toString(), expectedWriter.toString());
         }

--- a/incremental/src/test/java/net/automatalib/incremental/moore/AbstractIncrementalMooreBuilderTest.java
+++ b/incremental/src/test/java/net/automatalib/incremental/moore/AbstractIncrementalMooreBuilderTest.java
@@ -193,7 +193,7 @@ public abstract class AbstractIncrementalMooreBuilderTest {
                 getDOTResource()))) {
 
             GraphDOT.write(incMoore.asGraph(), dotWriter);
-            IOUtil.copy(reader, expectedWriter);
+            reader.transferTo(expectedWriter);
 
             Assert.assertEquals(dotWriter.toString(), expectedWriter.toString());
         }

--- a/modelchecking/ltsmin/pom.xml
+++ b/modelchecking/ltsmin/pom.xml
@@ -101,13 +101,6 @@ limitations under the License.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>javacc-maven-plugin</artifactId>
-                <configuration>
-                    <!-- We want to share the output directory with other annotation processors. While this config
-                         causes a warning during regular compilation, removing it causes an error when recompiling the
-                         code on a dirty target directory (e.g. done by the javadoc plugin during bundled builds).
-                    -->
-                    <outputDirectory>${project.build.directory}/generated-sources/annotations</outputDirectory>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/modelchecking/ltsmin/src/main/java/net/automatalib/modelchecker/ltsmin/ltl/AbstractLTSminLTL.java
+++ b/modelchecking/ltsmin/src/main/java/net/automatalib/modelchecker/ltsmin/ltl/AbstractLTSminLTL.java
@@ -61,7 +61,7 @@ public abstract class AbstractLTSminLTL<I, A, L extends Lasso<I, ?>> extends Abs
                                 int minimumUnfolds,
                                 double multiplier) {
         super(keepFiles, string2Input);
-        unfolder = new AbstractUnfoldingModelChecker<I, A, String, L>(minimumUnfolds, multiplier) {
+        unfolder = new AbstractUnfoldingModelChecker<>(minimumUnfolds, multiplier) {
 
             @Override
             public @Nullable L findCounterExample(A automaton, Collection<? extends I> inputs, String property) {

--- a/modelchecking/m3c/src/test/java/net/automatalib/modelchecker/m3c/solver/AbstractSolverTest.java
+++ b/modelchecking/m3c/src/test/java/net/automatalib/modelchecker/m3c/solver/AbstractSolverTest.java
@@ -113,7 +113,7 @@ public abstract class AbstractSolverTest<T extends AbstractPropertyTransformer<T
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     void testSolveWithInvalidMainProcess() {
-        ContextFreeModalProcessSystem<String, String> cfmps = new ContextFreeModalProcessSystem<String, String>() {
+        ContextFreeModalProcessSystem<String, String> cfmps = new ContextFreeModalProcessSystem<>() {
 
             @Override
             public Map<String, ProceduralModalProcessGraph<?, String, ?, String, ?>> getPMPGs() {
@@ -130,7 +130,7 @@ public abstract class AbstractSolverTest<T extends AbstractPropertyTransformer<T
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     void testSolveWithNoMainProcess() {
-        ContextFreeModalProcessSystem<String, String> cfmps = new ContextFreeModalProcessSystem<String, String>() {
+        ContextFreeModalProcessSystem<String, String> cfmps = new ContextFreeModalProcessSystem<>() {
 
             @Override
             public Map<String, ProceduralModalProcessGraph<?, String, ?, String, ?>> getPMPGs() {

--- a/pom.xml
+++ b/pom.xml
@@ -185,12 +185,9 @@ limitations under the License.
         <!-- general config -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.release>8</maven.compiler.release>
-        <maven.compiler.testSource>11</maven.compiler.testSource>
-        <maven.compiler.testTarget>11</maven.compiler.testTarget>
-        <maven.compiler.testRelease>11</maven.compiler.testRelease>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <argLine /> <!-- compatibility for property expansion in surefire-plugin -->
 
         <!-- plugin versions -->
@@ -199,7 +196,7 @@ limitations under the License.
         <assembly-plugin.version>3.7.1</assembly-plugin.version>
         <checkstyle-plugin.version>3.6.0</checkstyle-plugin.version>
         <clean-plugin.version>3.4.0</clean-plugin.version>
-        <compiler-plugin.version>3.11.0</compiler-plugin.version> <!-- changes to incremental compilation causes issues with our two compile phases. bump, once we completely switch to Java 11 -->
+        <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <coveralls-plugin.version>4.3.0</coveralls-plugin.version>
         <dependency-plugin.version>3.8.1</dependency-plugin.version>
         <deploy-plugin.version>3.1.3</deploy-plugin.version>
@@ -247,7 +244,7 @@ limitations under the License.
         <brics-automaton.apidocs>https://www.brics.dk/automaton/doc</brics-automaton.apidocs>
         <checkerframework.apidocs>https://checkerframework.org/releases/${checkerframework.version}/api/</checkerframework.apidocs>
         <guava.apidocs>http://google.github.io/guava/releases/${guava.version}/api/docs/</guava.apidocs>
-        <java8.apidocs>https://docs.oracle.com/javase/8/docs/api/</java8.apidocs>
+        <java11.apidocs>https://docs.oracle.com/javase/11/docs/api/</java11.apidocs>
         <jung.apidocs>https://jrtom.github.io/jung/javadoc/</jung.apidocs>
     </properties>
 
@@ -643,9 +640,6 @@ limitations under the License.
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>javacc-maven-plugin</artifactId>
                     <version>${javacc-plugin.version}</version>
-                    <configuration>
-                        <outputDirectory>${project.build.directory}/generated-sources/</outputDirectory>
-                    </configuration>
                     <executions>
                         <execution>
                             <id>javacc</id>
@@ -797,37 +791,6 @@ limitations under the License.
                             </path>
                         </annotationProcessorPaths>
                     </configuration>
-                    <executions>
-                        <execution>
-                            <id>default-compile</id>
-                            <goals>
-                                <goal>compile</goal>
-                            </goals>
-                            <configuration>
-                                <!-- compile everything in module-aware mode to check for errors -->
-                                <release>9</release>
-                                <createMissingPackageInfoClass>false</createMissingPackageInfoClass>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>java-8-compile</id>
-                            <goals>
-                                <goal>compile</goal>
-                            </goals>
-                            <configuration>
-                                <!-- recompile generated sources as well -->
-                                <compileSourceRoots>
-                                    <compileSourceRoot>${project.build.sourceDirectory}</compileSourceRoot>
-                                    <compileSourceRoot>${project.build.directory}/generated-sources</compileSourceRoot>
-                                </compileSourceRoots>
-                                <proc>none</proc>
-                                <!-- re-compile everything for target VM except the module-info.java -->
-                                <excludes>
-                                    <exclude>module-info.java</exclude>
-                                </excludes>
-                            </configuration>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -901,7 +864,6 @@ limitations under the License.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <release>11</release>
                     <!-- TODO preferably we would use the maven-dependency-plugin:properties goal for this (like in the
                     jung-visualization module) but this would require a dependency on the artifact :( -->
                     <additionalJOption>--patch-module=jung.api=${settings.localRepository}/net/sf/jung/jung-graph-impl/${jung.version}/jung-graph-impl-${jung.version}.jar</additionalJOption>

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,6 @@ limitations under the License.
         <brics-automaton.apidocs>https://www.brics.dk/automaton/doc</brics-automaton.apidocs>
         <checkerframework.apidocs>https://checkerframework.org/releases/${checkerframework.version}/api/</checkerframework.apidocs>
         <guava.apidocs>http://google.github.io/guava/releases/${guava.version}/api/docs/</guava.apidocs>
-        <java11.apidocs>https://docs.oracle.com/javase/11/docs/api/</java11.apidocs>
         <jung.apidocs>https://jrtom.github.io/jung/javadoc/</jung.apidocs>
     </properties>
 

--- a/serialization/dot/src/test/java/net/automatalib/serialization/dot/DOTSerializationTest.java
+++ b/serialization/dot/src/test/java/net/automatalib/serialization/dot/DOTSerializationTest.java
@@ -236,7 +236,7 @@ public class DOTSerializationTest {
 
         try (Reader reader = IOUtil.asBufferedUTF8Reader(DOTSerializationUtil.class.getResourceAsStream(resource))) {
 
-            IOUtil.copy(reader, expectedWriter);
+            reader.transferTo(expectedWriter);
             writer.write(dotWriter);
 
             Assert.assertEquals(dotWriter.toString(), expectedWriter.toString());

--- a/serialization/dot/src/test/java/net/automatalib/serialization/dot/DOTSerializationTest.java
+++ b/serialization/dot/src/test/java/net/automatalib/serialization/dot/DOTSerializationTest.java
@@ -111,14 +111,11 @@ public class DOTSerializationTest {
 
         final Graph<?, ?> dfa = DOTSerializationUtil.DFA.graphView();
         final Graph<?, ?> mealy =
-                new MealyGraphView<Integer, String, CompactTransition<String>, String, CompactMealy<String, String>>(
-                        DOTSerializationUtil.MEALY,
-                        DOTSerializationUtil.MEALY.getInputAlphabet()) {
+                new MealyGraphView<>(DOTSerializationUtil.MEALY, DOTSerializationUtil.MEALY.getInputAlphabet()) {
 
                     @Override
                     public VisualizationHelper<Integer, TransitionEdge<String, CompactTransition<String>>> getVisualizationHelper() {
-                        return new DefaultDOTVisualizationHelper<Integer, TransitionEdge<String, CompactTransition<String>>>(
-                                super.getVisualizationHelper()) {
+                        return new DefaultDOTVisualizationHelper<>(super.getVisualizationHelper()) {
 
                             @Override
                             public void writePreamble(Appendable a) throws IOException {

--- a/util/src/main/java/net/automatalib/util/automaton/ads/BacktrackingSearch.java
+++ b/util/src/main/java/net/automatalib/util/automaton/ads/BacktrackingSearch.java
@@ -180,7 +180,7 @@ public final class BacktrackingSearch {
                             succ = ADS.compute(automaton, input, currentNode);
                         }
 
-                        if (!succ.isPresent()) {
+                        if (succ.isEmpty()) {
                             cache.add(currentNodeAsBitSet);
                             continue oneSymbolFuture;
                         }
@@ -339,7 +339,7 @@ public final class BacktrackingSearch {
                                                                                               new HashSet<>(),
                                                                                               bestCosts);
 
-                    if (!potentialResult.isPresent()) {
+                    if (potentialResult.isEmpty()) {
                         continue alphabetLoop;
                     }
 
@@ -369,7 +369,7 @@ public final class BacktrackingSearch {
                                                                                           nextTraceCache,
                                                                                           bestCosts);
 
-                if (!potentialResult.isPresent()) {
+                if (potentialResult.isEmpty()) {
                     continue alphabetLoop;
                 }
 

--- a/util/src/test/java/net/automatalib/util/automaton/procedural/SPAsTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/procedural/SPAsTest.java
@@ -630,7 +630,7 @@ public class SPAsTest {
         final StringWriter expectedWriter = new StringWriter();
 
         try (Reader reader = IOUtil.asBufferedUTF8Reader(SPAsTest.class.getResourceAsStream(expected))) {
-            IOUtil.copy(reader, expectedWriter);
+            reader.transferTo(expectedWriter);
             GraphDOT.write(cfmps, dotWriter);
             Assert.assertEquals(dotWriter.toString(), expectedWriter.toString());
         }

--- a/visualization/dot-visualizer/src/test/java/net/automatalib/visualization/dot/DOTDialogTest.java
+++ b/visualization/dot-visualizer/src/test/java/net/automatalib/visualization/dot/DOTDialogTest.java
@@ -133,7 +133,7 @@ public class DOTDialogTest extends AssertJSwingTestngTestCase {
     }
 
     private static <T extends AbstractButton> GenericTypeMatcher<T> findByText(Class<T> clazz, String name) {
-        return new GenericTypeMatcher<T>(clazz) {
+        return new GenericTypeMatcher<>(clazz) {
 
             @Override
             protected boolean isMatching(T item) {

--- a/visualization/jung-visualizer/pom.xml
+++ b/visualization/jung-visualizer/pom.xml
@@ -173,6 +173,18 @@ limitations under the License.
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!-- The plugin doesn't like dependencies with missing module names so build with JPMS disabled -->
+                    <legacyMode>true</legacyMode>
+                    <disableSourcepathUsage>true</disableSourcepathUsage>
+                    <sourceFileExcludes>
+                        <sourceFileExclude>**\/module-info.java</sourceFileExclude>
+                    </sourceFileExcludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
There does not seem to be a need for supporting Java 8 anymore, so simplify our build process and benefit from some language goodies.