### PR TITLE
Bump Java Version to 17/25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: "Tests and Analysis (JDK: ${{ matrix.jdk }})"
     strategy:
       matrix:
-        jdk: [ 11, 17, 21 ]
+        jdk: [ 17, 21, 25 ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -45,7 +45,7 @@ jobs:
     needs: [ tests-and-analysis ]
     strategy:
       matrix:
-        jdk: [ 11, 17, 21 ]
+        jdk: [ 17, 21, 25 ]
         os: [ ubuntu-latest, windows-latest, macos-13, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -77,7 +77,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
       - name: Set up cache
         uses: actions/cache@v4
         with:
@@ -117,7 +117,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
       - name: Set up cache
         uses: actions/cache@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   * `BricsTransitionProperty`
   * `TransitionEdge{,.Property}`
   * `ProbabilisticOutput`
+  * `LTSminVersion`
 * The following class hierarchies have been made `sealed`:
   * `CommonAttrs`
   * `CommonStyles`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * `IOUtil#copy(Reader, Writer)` has been removed. Use `Reader#transferTo(Writer)` instead.
 * `JVMUtil` has been removed. Use `Runtime.version().feature()` for its previously (only) provided method.
 
+### Fixed
+
+* `SPAConverter.ConversionResult` is now publicly accessible.
+
 
 ## [0.12.1] - 2025-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-* AutomataLib now requires Java 11 at runtime.
+* AutomataLib now requires Java 17 at runtime.
+* The following classes have been refactored to `record`s:
+  * `BricsTransitionProperty`
+  * `TransitionEdge{,.Property}`
+  * `ProbabilisticOutput`
+* The following classes have been refactored to `sealed` classes:
+  * `CommonAttrs`
+  * `EdgeAttrs`
+  * `CommonStyles`
 * `ProcessUtil#invokeProcess` now handles consumers for stdout and stderr separately.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   * `BricsTransitionProperty`
   * `TransitionEdge{,.Property}`
   * `ProbabilisticOutput`
-* The following classes have been refactored to `sealed` classes:
+* The following class hierarchies have been made `sealed`:
   * `CommonAttrs`
-  * `EdgeAttrs`
   * `CommonStyles`
 * `ProcessUtil#invokeProcess` now handles consumers for stdout and stderr separately.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Contributions -- whether it is in the form of new features, better documentation
 
 For simply using AutomataLib you may use the Maven artifacts which are available in the [Maven Central repository][maven-central].
 It is also possible to download a bundled [distribution artifact][maven-central-distr] if you want to use AutomataLib without Maven support.
-Note that AutomataLib requires Java 11 (or newer) to build and run.
+Note that AutomataLib requires Java 17 (or newer) to build but still supports Java 11 at runtim.
 
 #### Building development versions
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Contributions -- whether it is in the form of new features, better documentation
 
 For simply using AutomataLib you may use the Maven artifacts which are available in the [Maven Central repository][maven-central].
 It is also possible to download a bundled [distribution artifact][maven-central-distr] if you want to use AutomataLib without Maven support.
-Note that AutomataLib requires Java 17 (or newer) to build but still supports Java 11 at runtim.
+Note that AutomataLib requires Java 17 (or newer) to build and run.
 
 #### Building development versions
 

--- a/adapters/brics/src/main/java/net/automatalib/brics/BricsTransitionProperty.java
+++ b/adapters/brics/src/main/java/net/automatalib/brics/BricsTransitionProperty.java
@@ -16,15 +16,16 @@
 package net.automatalib.brics;
 
 import dk.brics.automaton.Transition;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * The properties of an edge in a Brics automaton.
+ *
+ * @param min
+ *         lower bound of the character range.
+ * @param max
+ *         upper bound of the character range.
  */
-public class BricsTransitionProperty {
-
-    private final char min;
-    private final char max;
+public record BricsTransitionProperty(char min, char max) {
 
     /**
      * Constructor. Constructs the property from a Brics {@link Transition}.
@@ -34,41 +35,6 @@ public class BricsTransitionProperty {
      */
     public BricsTransitionProperty(Transition trans) {
         this(trans.getMin(), trans.getMax());
-    }
-
-    /**
-     * Constructor.
-     *
-     * @param min
-     *         lower bound of the character range.
-     * @param max
-     *         upper bound of the character range.
-     */
-    public BricsTransitionProperty(char min, char max) {
-        this.min = min;
-        this.max = max;
-    }
-
-    /**
-     * Retrieves the lower bound of the character range.
-     *
-     * @return the lower bound of the character range
-     *
-     * @see Transition#getMin()
-     */
-    public char getMin() {
-        return min;
-    }
-
-    /**
-     * Retrieves the upper bound of the character range.
-     *
-     * @return the upper bound of the character range
-     *
-     * @see Transition#getMax()
-     */
-    public char getMax() {
-        return max;
     }
 
     @Override
@@ -83,26 +49,5 @@ public class BricsTransitionProperty {
             sb.append("..'").append(max).append('\'');
         }
         return sb.toString();
-    }
-
-    @Override
-    public final boolean equals(@Nullable Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof BricsTransitionProperty)) {
-            return false;
-        }
-
-        final BricsTransitionProperty that = (BricsTransitionProperty) o;
-        return min == that.min && max == that.max;
-    }
-
-    @Override
-    public final int hashCode() {
-        int result = 1;
-        result = 31 * result + Character.hashCode(min);
-        result = 31 * result + Character.hashCode(max);
-        return result;
     }
 }

--- a/api/src/main/java/net/automatalib/alphabet/Alphabet.java
+++ b/api/src/main/java/net/automatalib/alphabet/Alphabet.java
@@ -125,8 +125,8 @@ public interface Alphabet<I> extends ArrayWritable<I>, Collection<I>, Comparator
      *         if {@code this} alphabet does not implement {@link GrowingAlphabet}
      */
     default GrowingAlphabet<I> asGrowingAlphabetOrThrowException() {
-        if (this instanceof GrowingAlphabet) {
-            return (GrowingAlphabet<I>) this;
+        if (this instanceof GrowingAlphabet<I> result) {
+            return result;
         } else {
             throw new GrowingAlphabetNotSupportedException(this);
         }

--- a/api/src/main/java/net/automatalib/alphabet/SupportsGrowingAlphabet.java
+++ b/api/src/main/java/net/automatalib/alphabet/SupportsGrowingAlphabet.java
@@ -23,6 +23,7 @@ import net.automatalib.exception.GrowingAlphabetNotSupportedException;
  * @param <I>
  *         input alphabet type
  */
+@FunctionalInterface
 public interface SupportsGrowingAlphabet<I> {
 
     /**

--- a/api/src/main/java/net/automatalib/automaton/concept/FiniteRepresentation.java
+++ b/api/src/main/java/net/automatalib/automaton/concept/FiniteRepresentation.java
@@ -23,6 +23,7 @@ import net.automatalib.automaton.simple.SimpleAutomaton;
  * {@link SimpleAutomaton}). For example, push-down systems can have infinitely many states but may be representable
  * with a finite amount of locations.
  */
+@FunctionalInterface
 public interface FiniteRepresentation {
 
     /**

--- a/api/src/main/java/net/automatalib/automaton/concept/InputAlphabetHolder.java
+++ b/api/src/main/java/net/automatalib/automaton/concept/InputAlphabetHolder.java
@@ -17,6 +17,7 @@ package net.automatalib.automaton.concept;
 
 import net.automatalib.alphabet.Alphabet;
 
+@FunctionalInterface
 public interface InputAlphabetHolder<I> {
 
     Alphabet<I> getInputAlphabet();

--- a/api/src/main/java/net/automatalib/automaton/concept/Output.java
+++ b/api/src/main/java/net/automatalib/automaton/concept/Output.java
@@ -34,10 +34,10 @@ public interface Output<I, D> {
     D computeOutput(Iterable<? extends I> input);
 
     static <T> WordBuilder<T> getBuilderFor(Iterable<?> iterable) {
-        if (iterable instanceof Word) {
-            return new WordBuilder<>(((Word<?>) iterable).length());
-        } else if (iterable instanceof Collection) {
-            return new WordBuilder<>(((Collection<?>) iterable).size());
+        if (iterable instanceof Word<?> w) {
+            return new WordBuilder<>(w.length());
+        } else if (iterable instanceof Collection<?> c) {
+            return new WordBuilder<>(c.size());
         } else {
             return new WordBuilder<>();
         }

--- a/api/src/main/java/net/automatalib/automaton/concept/Output.java
+++ b/api/src/main/java/net/automatalib/automaton/concept/Output.java
@@ -28,6 +28,7 @@ import net.automatalib.word.WordBuilder;
  * @param <D>
  *         output domain type
  */
+@FunctionalInterface
 public interface Output<I, D> {
 
     D computeOutput(Iterable<? extends I> input);

--- a/api/src/main/java/net/automatalib/automaton/concept/Probabilistic.java
+++ b/api/src/main/java/net/automatalib/automaton/concept/Probabilistic.java
@@ -15,6 +15,7 @@
  */
 package net.automatalib.automaton.concept;
 
+@FunctionalInterface
 public interface Probabilistic<T> {
 
     float getTransitionProbability(T transition);

--- a/api/src/main/java/net/automatalib/automaton/concept/StateLocalInput.java
+++ b/api/src/main/java/net/automatalib/automaton/concept/StateLocalInput.java
@@ -27,6 +27,7 @@ import java.util.Collection;
  * @param <I>
  *         input symbol type
  */
+@FunctionalInterface
 public interface StateLocalInput<S, I> {
 
     /**

--- a/api/src/main/java/net/automatalib/automaton/concept/StateOutput.java
+++ b/api/src/main/java/net/automatalib/automaton/concept/StateOutput.java
@@ -23,6 +23,7 @@ package net.automatalib.automaton.concept;
  * @param <O>
  *         output class.
  */
+@FunctionalInterface
 public interface StateOutput<S, O> {
 
     O getStateOutput(S state);

--- a/api/src/main/java/net/automatalib/automaton/concept/SuffixOutput.java
+++ b/api/src/main/java/net/automatalib/automaton/concept/SuffixOutput.java
@@ -29,6 +29,7 @@ import net.automatalib.word.Word;
  * @param <D>
  *         output domain type
  */
+@FunctionalInterface
 public interface SuffixOutput<I, D> extends Output<I, D> {
 
     @Override

--- a/api/src/main/java/net/automatalib/automaton/concept/TransitionOutput.java
+++ b/api/src/main/java/net/automatalib/automaton/concept/TransitionOutput.java
@@ -23,6 +23,7 @@ package net.automatalib.automaton.concept;
  * @param <O>
  *         output class.
  */
+@FunctionalInterface
 public interface TransitionOutput<T, O> {
 
     O getTransitionOutput(T transition);

--- a/api/src/main/java/net/automatalib/automaton/graph/AutomatonGraphView.java
+++ b/api/src/main/java/net/automatalib/automaton/graph/AutomatonGraphView.java
@@ -55,7 +55,7 @@ public class AutomatonGraphView<S, I, T, A extends Automaton<S, I, T>>
 
     @Override
     public S getTarget(TransitionEdge<I, T> edge) {
-        return automaton.getSuccessor(edge.getTransition());
+        return automaton.getSuccessor(edge.transition());
     }
 
     @Override

--- a/api/src/main/java/net/automatalib/automaton/graph/TransitionEdge.java
+++ b/api/src/main/java/net/automatalib/automaton/graph/TransitionEdge.java
@@ -15,91 +15,13 @@
  */
 package net.automatalib.automaton.graph;
 
-import java.util.Objects;
-
 import net.automatalib.ts.UniversalTransitionSystem;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
-public final class TransitionEdge<I, T> {
-
-    private final I input;
-    private final T transition;
-
-    public TransitionEdge(I input, T transition) {
-        this.input = input;
-        this.transition = transition;
-    }
-
-    public I getInput() {
-        return input;
-    }
-
-    public T getTransition() {
-        return transition;
-    }
+public record TransitionEdge<I, T>(I input, T transition) {
 
     public <TP> Property<I, TP> property(UniversalTransitionSystem<?, ?, T, ?, TP> uts) {
         return new Property<>(input, uts.getTransitionProperty(transition));
     }
 
-    @Override
-    public boolean equals(@Nullable Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof TransitionEdge)) {
-            return false;
-        }
-
-        final TransitionEdge<?, ?> that = (TransitionEdge<?, ?>) o;
-        return Objects.equals(input, that.input) && Objects.equals(transition, that.transition);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = 1;
-        result = 31 * result + Objects.hashCode(input);
-        result = 31 * result + Objects.hashCode(transition);
-        return result;
-    }
-
-    public static final class Property<I, TP> {
-
-        private final I input;
-        private final TP property;
-
-        public Property(I input, TP property) {
-            this.input = input;
-            this.property = property;
-        }
-
-        public I getInput() {
-            return input;
-        }
-
-        public TP getProperty() {
-            return property;
-        }
-
-        @Override
-        public boolean equals(@Nullable Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (!(o instanceof Property)) {
-                return false;
-            }
-
-            final Property<?, ?> that = (Property<?, ?>) o;
-            return Objects.equals(input, that.input) && Objects.equals(property, that.property);
-        }
-
-        @Override
-        public int hashCode() {
-            int result = 1;
-            result = 31 * result + Objects.hashCode(input);
-            result = 31 * result + Objects.hashCode(property);
-            return result;
-        }
-    }
+    public record Property<I, TP>(I input, TP property) {}
 }

--- a/api/src/main/java/net/automatalib/automaton/graph/UniversalAutomatonGraphView.java
+++ b/api/src/main/java/net/automatalib/automaton/graph/UniversalAutomatonGraphView.java
@@ -36,7 +36,7 @@ public class UniversalAutomatonGraphView<S, I, T, SP, TP, A extends UniversalAut
 
     @Override
     public Property<I, TP> getEdgeProperty(TransitionEdge<I, T> edge) {
-        return new TransitionEdge.Property<>(edge.getInput(), automaton.getTransitionProperty(edge.getTransition()));
+        return new TransitionEdge.Property<>(edge.input(), automaton.getTransitionProperty(edge.transition()));
     }
 
 }

--- a/api/src/main/java/net/automatalib/automaton/transducer/probabilistic/ProbabilisticMealyMachine.java
+++ b/api/src/main/java/net/automatalib/automaton/transducer/probabilistic/ProbabilisticMealyMachine.java
@@ -32,11 +32,11 @@ public interface ProbabilisticMealyMachine<S, I, T, O> extends Automaton<S, I, T
 
     @Override
     default float getTransitionProbability(T transition) {
-        return getTransitionProperty(transition).getProbability();
+        return getTransitionProperty(transition).probability();
     }
 
     @Override
     default O getTransitionOutput(T transition) {
-        return getTransitionProperty(transition).getOutput();
+        return getTransitionProperty(transition).output();
     }
 }

--- a/api/src/main/java/net/automatalib/automaton/transducer/probabilistic/ProbabilisticOutput.java
+++ b/api/src/main/java/net/automatalib/automaton/transducer/probabilistic/ProbabilisticOutput.java
@@ -15,46 +15,4 @@
  */
 package net.automatalib.automaton.transducer.probabilistic;
 
-import java.util.Objects;
-
-import org.checkerframework.checker.nullness.qual.Nullable;
-
-public final class ProbabilisticOutput<O> {
-
-    private final float probability;
-    private final O output;
-
-    public ProbabilisticOutput(float probability, O output) {
-        this.probability = probability;
-        this.output = output;
-    }
-
-    public float getProbability() {
-        return probability;
-    }
-
-    public O getOutput() {
-        return output;
-    }
-
-    @Override
-    public boolean equals(@Nullable Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof ProbabilisticOutput)) {
-            return false;
-        }
-
-        final ProbabilisticOutput<?> that = (ProbabilisticOutput<?>) o;
-        return Float.compare(probability, that.probability) == 0 && Objects.equals(output, that.output);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = 1;
-        result = 31 * result + Float.hashCode(probability);
-        result = 31 * result + Objects.hashCode(output);
-        return result;
-    }
-}
+public record ProbabilisticOutput<O>(float probability, O output) {}

--- a/api/src/main/java/net/automatalib/automaton/visualization/AutomatonVisualizationHelper.java
+++ b/api/src/main/java/net/automatalib/automaton/visualization/AutomatonVisualizationHelper.java
@@ -40,7 +40,7 @@ public class AutomatonVisualizationHelper<S, I, T, A extends Automaton<S, I, T>>
     public boolean getEdgeProperties(S src, TransitionEdge<I, T> edge, S tgt, Map<String, String> properties) {
         super.getEdgeProperties(src, edge, tgt, properties);
 
-        properties.put(EdgeAttrs.LABEL, String.valueOf(edge.getInput()));
+        properties.put(EdgeAttrs.LABEL, String.valueOf(edge.input()));
 
         return true;
     }

--- a/api/src/main/java/net/automatalib/automaton/visualization/MTSVisualizationHelper.java
+++ b/api/src/main/java/net/automatalib/automaton/visualization/MTSVisualizationHelper.java
@@ -32,7 +32,7 @@ public class MTSVisualizationHelper<S, I, T, TP extends ModalEdgeProperty, M ext
     public boolean getEdgeProperties(S src, TransitionEdge<I, T> edge, S tgt, Map<String, String> properties) {
         super.getEdgeProperties(src, edge, tgt, properties);
 
-        final TP transitionProperty = super.automaton.getTransitionProperty(edge.getTransition());
+        final TP transitionProperty = super.automaton.getTransitionProperty(edge.transition());
 
         if (transitionProperty.isMayOnly()) {
             properties.put(EdgeAttrs.STYLE, EdgeStyles.DASHED);

--- a/api/src/main/java/net/automatalib/automaton/visualization/MealyVisualizationHelper.java
+++ b/api/src/main/java/net/automatalib/automaton/visualization/MealyVisualizationHelper.java
@@ -32,8 +32,8 @@ public class MealyVisualizationHelper<S, I, T, O>
         super.getEdgeProperties(src, edge, tgt, properties);
 
         final StringBuilder labelBuilder = new StringBuilder();
-        labelBuilder.append(edge.getInput()).append(" / ");
-        O output = automaton.getTransitionOutput(edge.getTransition());
+        labelBuilder.append(edge.input()).append(" / ");
+        O output = automaton.getTransitionOutput(edge.transition());
         if (output != null) {
             labelBuilder.append(output);
         }

--- a/api/src/main/java/net/automatalib/automaton/visualization/SSTVisualizationHelper.java
+++ b/api/src/main/java/net/automatalib/automaton/visualization/SSTVisualizationHelper.java
@@ -32,8 +32,8 @@ public class SSTVisualizationHelper<S, I, T, O>
     public boolean getEdgeProperties(S src, TransitionEdge<I, T> edge, S tgt, Map<String, String> properties) {
         super.getEdgeProperties(src, edge, tgt, properties);
 
-        final Word<O> output = automaton.getTransitionProperty(edge.getTransition());
-        properties.put(EdgeAttrs.LABEL, edge.getInput() + " / " + output);
+        final Word<O> output = automaton.getTransitionProperty(edge.transition());
+        properties.put(EdgeAttrs.LABEL, edge.input() + " / " + output);
 
         return true;
     }

--- a/api/src/main/java/net/automatalib/graph/concept/EdgeLabels.java
+++ b/api/src/main/java/net/automatalib/graph/concept/EdgeLabels.java
@@ -25,6 +25,7 @@ import net.automatalib.graph.Graph;
  * @param <L>
  *         label class
  */
+@FunctionalInterface
 public interface EdgeLabels<E, L> {
 
     /**

--- a/api/src/main/java/net/automatalib/graph/concept/EdgeWeights.java
+++ b/api/src/main/java/net/automatalib/graph/concept/EdgeWeights.java
@@ -21,6 +21,7 @@ package net.automatalib.graph.concept;
  * @param <E>
  *         edge class
  */
+@FunctionalInterface
 public interface EdgeWeights<E> {
 
     /**

--- a/api/src/main/java/net/automatalib/graph/concept/FinalNode.java
+++ b/api/src/main/java/net/automatalib/graph/concept/FinalNode.java
@@ -17,6 +17,7 @@ package net.automatalib.graph.concept;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+@FunctionalInterface
 public interface FinalNode<N> {
 
     /**

--- a/api/src/main/java/net/automatalib/graph/concept/GraphViewable.java
+++ b/api/src/main/java/net/automatalib/graph/concept/GraphViewable.java
@@ -17,6 +17,7 @@ package net.automatalib.graph.concept;
 
 import net.automatalib.graph.Graph;
 
+@FunctionalInterface
 public interface GraphViewable {
 
     Graph<?, ?> graphView();

--- a/api/src/main/java/net/automatalib/graph/concept/InitialNode.java
+++ b/api/src/main/java/net/automatalib/graph/concept/InitialNode.java
@@ -23,6 +23,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @param <N>
  *         node class.
  */
+@FunctionalInterface
 public interface InitialNode<N> {
 
     /**

--- a/api/src/main/java/net/automatalib/graph/concept/KripkeInterpretation.java
+++ b/api/src/main/java/net/automatalib/graph/concept/KripkeInterpretation.java
@@ -26,6 +26,7 @@ import java.util.Set;
  * @param <AP>
  *         atomic proposition class
  */
+@FunctionalInterface
 public interface KripkeInterpretation<N, AP> {
 
     /**

--- a/api/src/main/java/net/automatalib/graph/concept/NodeAcceptance.java
+++ b/api/src/main/java/net/automatalib/graph/concept/NodeAcceptance.java
@@ -23,6 +23,7 @@ import net.automatalib.graph.Graph;
  * @param <N>
  *         node class
  */
+@FunctionalInterface
 public interface NodeAcceptance<N> {
 
     /**

--- a/api/src/main/java/net/automatalib/modelchecking/ModelChecker.java
+++ b/api/src/main/java/net/automatalib/modelchecking/ModelChecker.java
@@ -36,6 +36,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @param <R>
  *         the type of counterexample
  */
+@FunctionalInterface
 public interface ModelChecker<I, A, P, R> {
 
     /**
@@ -55,6 +56,7 @@ public interface ModelChecker<I, A, P, R> {
      */
     @Nullable R findCounterExample(A automaton, Collection<? extends I> inputs, P property);
 
+    @FunctionalInterface
     interface DFAModelChecker<I, P, R> extends ModelChecker<I, DFA<?, I>, P, R> {}
 
     /**

--- a/api/src/main/java/net/automatalib/serialization/InputModelDeserializer.java
+++ b/api/src/main/java/net/automatalib/serialization/InputModelDeserializer.java
@@ -26,4 +26,5 @@ import net.automatalib.ts.simple.SimpleTS;
  * @param <M>
  *         the type of objects implementing classes can deserialize
  */
+@FunctionalInterface
 public interface InputModelDeserializer<I, M extends SimpleTS<?, I>> extends ModelDeserializer<InputModelData<I, M>> {}

--- a/api/src/main/java/net/automatalib/serialization/InputModelSerializer.java
+++ b/api/src/main/java/net/automatalib/serialization/InputModelSerializer.java
@@ -33,6 +33,7 @@ import net.automatalib.ts.simple.SimpleTS;
  * @param <M>
  *         the type of objects implementing classes can deserialize
  */
+@FunctionalInterface
 public interface InputModelSerializer<I, M extends SimpleTS<?, I>> extends ModelSerializer<InputModelData<I, M>> {
 
     /**

--- a/api/src/main/java/net/automatalib/serialization/ModelDeserializer.java
+++ b/api/src/main/java/net/automatalib/serialization/ModelDeserializer.java
@@ -31,6 +31,7 @@ import net.automatalib.exception.FormatException;
  * @param <M>
  *         the type of objects implementing classes can deserialize
  */
+@FunctionalInterface
 public interface ModelDeserializer<M> {
 
     /**

--- a/api/src/main/java/net/automatalib/serialization/ModelSerializer.java
+++ b/api/src/main/java/net/automatalib/serialization/ModelSerializer.java
@@ -28,6 +28,7 @@ import net.automatalib.common.util.IOUtil;
  * @param <M>
  *         the type of objects implementing classes can serialize
  */
+@FunctionalInterface
 public interface ModelSerializer<M> {
 
     /**

--- a/api/src/main/java/net/automatalib/ts/modal/transition/ModalEdgeProperty.java
+++ b/api/src/main/java/net/automatalib/ts/modal/transition/ModalEdgeProperty.java
@@ -15,6 +15,7 @@
  */
 package net.automatalib.ts.modal.transition;
 
+@FunctionalInterface
 public interface ModalEdgeProperty {
 
     enum ModalType {

--- a/api/src/main/java/net/automatalib/visualization/VisualizationHelper.java
+++ b/api/src/main/java/net/automatalib/visualization/VisualizationHelper.java
@@ -71,7 +71,7 @@ public interface VisualizationHelper<N, E> {
      */
     boolean getEdgeProperties(N src, E edge, N tgt, Map<String, String> properties);
 
-    class CommonAttrs {
+    sealed class CommonAttrs permits NodeAttrs, EdgeAttrs {
 
         public static final String LABEL = "label";
         public static final String COLOR = "color";
@@ -97,12 +97,21 @@ public interface VisualizationHelper<N, E> {
         }
     }
 
-    class EdgeAttrs extends CommonAttrs {
+    sealed class EdgeAttrs extends CommonAttrs permits MTSEdgeAttrs {
 
         public static final String PENWIDTH = "penwidth";
         public static final String ARROWHEAD = "arrowhead";
 
         private EdgeAttrs() {
+            // prevent instantiation
+        }
+    }
+
+    final class MTSEdgeAttrs extends EdgeAttrs {
+
+        public static final String MODALITY = "modality";
+
+        private MTSEdgeAttrs() {
             // prevent instantiation
         }
     }
@@ -127,7 +136,7 @@ public interface VisualizationHelper<N, E> {
         }
     }
 
-    class CommonStyles {
+    sealed class CommonStyles permits NodeStyles, EdgeStyles {
 
         public static final String DASHED = "dashed";
         public static final String DOTTED = "dotted";
@@ -154,15 +163,6 @@ public interface VisualizationHelper<N, E> {
     final class EdgeStyles extends CommonStyles {
 
         private EdgeStyles() {
-            // prevent instantiation
-        }
-    }
-
-    final class MTSEdgeAttrs extends EdgeAttrs {
-
-        public static final String MODALITY = "modality";
-
-        private MTSEdgeAttrs() {
             // prevent instantiation
         }
     }

--- a/api/src/main/java/net/automatalib/word/Word.java
+++ b/api/src/main/java/net/automatalib/word/Word.java
@@ -262,10 +262,9 @@ public abstract class Word<I> extends AbstractPrintable implements ArrayWritable
         if (this == other) {
             return true;
         }
-        if (!(other instanceof Word)) {
+        if (!(other instanceof Word<?> otherWord)) {
             return false;
         }
-        Word<?> otherWord = (Word<?>) other;
         int len = otherWord.length();
         if (len != length()) {
             return false;

--- a/api/src/test/java/net/automatalib/word/AbstractWordTest.java
+++ b/api/src/test/java/net/automatalib/word/AbstractWordTest.java
@@ -191,17 +191,17 @@ public abstract class AbstractWordTest {
 
     @Test
     public void testEquals() {
-        Assert.assertTrue(testWord.equals(testWord));
+        Assert.assertEquals(testWord, testWord);
         Assert.assertFalse(testWord.equals(null));
 
         for (Word<?> eq : equalWords) {
-            Assert.assertTrue(testWord.equals(eq));
-            Assert.assertTrue(eq.equals(testWord));
+            Assert.assertEquals(eq, testWord);
+            Assert.assertEquals(testWord, eq);
         }
 
         for (Word<?> neq : unequalWords) {
-            Assert.assertFalse(testWord.equals(neq));
-            Assert.assertFalse(neq.equals(testWord));
+            Assert.assertNotEquals(neq, testWord);
+            Assert.assertNotEquals(testWord, neq);
         }
     }
 

--- a/archetypes/basic/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/basic/src/main/resources/archetype-resources/pom.xml
@@ -11,9 +11,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <!-- AutomataLib requires Java 8 -->
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- AutomataLib requires Java 17 -->
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
 
         <!-- Version of AutomataLib to use -->
         <automatalib.version>${automatalibVersion}</automatalib.version>

--- a/archetypes/complete/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/complete/src/main/resources/archetype-resources/pom.xml
@@ -11,9 +11,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <!-- AutomataLib requires Java 8 -->
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- AutomataLib requires Java 17 -->
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
 
         <!-- Version of AutomataLib to use -->
         <automatalib.version>${automatalibVersion}</automatalib.version>

--- a/build-config/src/main/resources/automatalib-checkstyle-suppressions.xml
+++ b/build-config/src/main/resources/automatalib-checkstyle-suppressions.xml
@@ -23,4 +23,7 @@ limitations under the License.
     <suppress checks="." files="target/*"/>
 
     <suppress checks="MagicNumber" files="src/test/*"/>
+
+    <!-- PMD.ExhaustiveSwitchHasDefault checks exhaustiveness -->
+    <suppress checks="MissingSwitchDefault" files="."/>
 </suppressions>

--- a/build-config/src/main/resources/automatalib-checkstyle-suppressions.xml
+++ b/build-config/src/main/resources/automatalib-checkstyle-suppressions.xml
@@ -20,10 +20,11 @@ limitations under the License.
 
 <suppressions>
     <suppress checks="AbstractClassName" files="Word.java"/>
+    <!-- PMD checks for exhaustiveness and SpotBugs for missing branches -->
+    <suppress checks="MissingSwitchDefault" files="."/>
+
+    <!-- ignore generated sources -->
     <suppress checks="." files="target/*"/>
 
     <suppress checks="MagicNumber" files="src/test/*"/>
-
-    <!-- PMD.ExhaustiveSwitchHasDefault checks exhaustiveness -->
-    <suppress checks="MissingSwitchDefault" files="."/>
 </suppressions>

--- a/build-config/src/main/resources/automatalib-learnlib-checkstyle.xml
+++ b/build-config/src/main/resources/automatalib-learnlib-checkstyle.xml
@@ -194,7 +194,9 @@ limitations under the License.
         <module name="ParameterName"/>
         <module name="PatternVariableName"/>
         <module name="RecordComponentName"/>
-        <module name="RecordTypeParameterName"/>
+        <module name="RecordTypeParameterName">
+            <property name="format" value="^[A-Z][A-Z0-9]*$"/>
+        </module>
         <module name="StaticVariableName">
             <property name="format" value="^[a-zA-Z][a-zA-Z0-9]*$"/>
         </module>

--- a/build-config/src/main/resources/automatalib-pmd-ruleset.xml
+++ b/build-config/src/main/resources/automatalib-pmd-ruleset.xml
@@ -25,8 +25,6 @@ limitations under the License.
     <!-- EXCLUSIONS -->
 
     <rule ref="category/java/bestpractices.xml">
-        <exclude name="AccessorClassGeneration"/> <!-- irrelevant once we target Java 11 -->
-        <exclude name="AccessorMethodGeneration"/> <!-- irrelevant once we target Java 11 -->
         <exclude name="ArrayIsStoredDirectly"/>
         <exclude name="LooseCoupling"/> <!-- may be enabled once calls on sub-type methods are filtered again -->
         <exclude name="GuardLogStatement"/>
@@ -53,7 +51,6 @@ limitations under the License.
         <exclude name="ShortMethodName"/>
         <exclude name="ShortVariable"/>
         <exclude name="UnnecessaryBoxing"/> <!-- flags some false-positives currently -->
-        <exclude name="UnnecessaryImport"/> <!-- flags imports required by JavaDoc -->
     </rule>
 
     <rule ref="category/java/design.xml">
@@ -100,9 +97,21 @@ limitations under the License.
 
     <!-- CONFIGS -->
 
+    <rule ref="category/java/codestyle.xml/ConfusingTernary">
+        <properties>
+            <property name="ignoreElseIf" value="true" />
+        </properties>
+    </rule>
+
     <rule ref="category/java/codestyle.xml/EmptyControlStatement">
         <properties>
             <property name="allowCommentedBlocks" value="true" />
+        </properties>
+    </rule>
+
+    <rule ref="category/java/codestyle.xml/TypeParameterNamingConventions">
+        <properties>
+            <property name="typeParameterNamePattern" value="[A-Z0-9]*" />
         </properties>
     </rule>
 
@@ -110,12 +119,6 @@ limitations under the License.
         <properties>
             <property name="reportStaticMethods" value="false" />
             <property name="reportStaticFields" value="false" />
-        </properties>
-    </rule>
-
-    <rule ref="category/java/codestyle.xml/ConfusingTernary">
-        <properties>
-            <property name="ignoreElseIf" value="true" />
         </properties>
     </rule>
 

--- a/commons/settings/src/main/java/net/automatalib/common/setting/AutomataLibSettingsSource.java
+++ b/commons/settings/src/main/java/net/automatalib/common/setting/AutomataLibSettingsSource.java
@@ -17,4 +17,5 @@ package net.automatalib.common.setting;
 
 import net.automatalib.common.util.setting.SettingsSource;
 
+@FunctionalInterface
 public interface AutomataLibSettingsSource extends SettingsSource {}

--- a/commons/smartcollections/src/main/java/net/automatalib/common/smartcollection/BackedGeneralPriorityQueue.java
+++ b/commons/smartcollections/src/main/java/net/automatalib/common/smartcollection/BackedGeneralPriorityQueue.java
@@ -177,6 +177,7 @@ public class BackedGeneralPriorityQueue<E, K extends Comparable<K>> extends Abst
     /**
      * Note: this class has a natural ordering that is inconsistent with equals.
      */
+    @SuppressWarnings("PMD.OverrideBothEqualsAndHashCodeOnComparable")
     public static class Entry<E, K extends Comparable<K>> implements Comparable<Entry<E, K>> {
 
         public E element;

--- a/commons/util/src/main/java/net/automatalib/common/util/Pair.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/Pair.java
@@ -83,15 +83,8 @@ public final class Pair<T1, T2> extends AbstractPrintable {
 
     @Override
     public boolean equals(@Nullable Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof Pair)) {
-            return false;
-        }
-
-        final Pair<?, ?> that = (Pair<?, ?>) o;
-        return Objects.equals(first, that.first) && Objects.equals(second, that.second);
+        return this == o ||
+               o instanceof Pair<?, ?> that && Objects.equals(first, that.first) && Objects.equals(second, that.second);
     }
 
     @Override

--- a/commons/util/src/main/java/net/automatalib/common/util/Triple.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/Triple.java
@@ -97,16 +97,8 @@ public final class Triple<T1, T2, T3> extends AbstractPrintable {
 
     @Override
     public boolean equals(@Nullable Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof Triple)) {
-            return false;
-        }
-
-        final Triple<?, ?, ?> that = (Triple<?, ?, ?>) o;
-        return Objects.equals(first, that.first) && Objects.equals(second, that.second) &&
-               Objects.equals(third, that.third);
+        return this == o || o instanceof Triple<?, ?, ?> that && Objects.equals(first, that.first) &&
+                            Objects.equals(second, that.second) && Objects.equals(third, that.third);
     }
 
     @Override

--- a/commons/util/src/main/java/net/automatalib/common/util/WrapperUtil.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/WrapperUtil.java
@@ -31,7 +31,6 @@ public final class WrapperUtil {
         return (b != null) ? b : def;
     }
 
-    @SuppressWarnings("PMD.AvoidUsingShortType") // we don't perform arithmetic operations on Shorts, so usage is fine
     public static short shortValue(@Nullable Short s, short def) {
         return (s != null) ? s : def;
     }

--- a/commons/util/src/main/java/net/automatalib/common/util/array/ArrayStorage.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/array/ArrayStorage.java
@@ -161,26 +161,8 @@ public final class ArrayStorage<T> extends AbstractList<T> implements RandomAcce
 
     @Override
     public boolean equals(@Nullable Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof ArrayStorage)) {
-            return false;
-        }
-
-        final ArrayStorage<?> that = (ArrayStorage<?>) o;
-
-        if (this.size != that.size) {
-            return false;
-        }
-
-        for (int i = 0; i < this.size; i++) {
-            if (!Objects.equals(this.storage[i], that.storage[i])) {
-                return false;
-            }
-        }
-
-        return true;
+        return this == o || o instanceof ArrayStorage<?> that && this.size == that.size &&
+                            Arrays.equals(this.storage, 0, this.size, that.storage, 0, this.size);
     }
 
     @Override

--- a/commons/util/src/main/java/net/automatalib/common/util/collection/AbstractSimplifiedIterator.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/collection/AbstractSimplifiedIterator.java
@@ -55,14 +55,11 @@ public abstract class AbstractSimplifiedIterator<E> implements Iterator<E> {
 
     @Override
     public boolean hasNext() {
-        switch (state) {
-            case AWAIT_NEXT:
-                return advance();
-            case HAS_NEXT:
-                return true;
-            default: // case FINISHED:
-                return false;
-        }
+        return switch (state) {
+            case AWAIT_NEXT -> advance();
+            case HAS_NEXT -> true;
+            case FINISHED -> false;
+        };
     }
 
     @Override

--- a/commons/util/src/main/java/net/automatalib/common/util/collection/CollectionUtil.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/collection/CollectionUtil.java
@@ -49,8 +49,8 @@ public final class CollectionUtil {
     }
 
     public static <T> List<T> randomAccessList(Collection<T> coll) {
-        if (coll instanceof List && coll instanceof RandomAccess) {
-            return (List<T>) coll;
+        if (coll instanceof List<T> list && coll instanceof RandomAccess) {
+            return list;
         }
         return new ArrayList<>(coll);
     }

--- a/commons/util/src/main/java/net/automatalib/common/util/collection/IterableUtil.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/collection/IterableUtil.java
@@ -135,8 +135,8 @@ public final class IterableUtil {
      * @return the number of elements of the iterable
      */
     public static int size(Iterable<?> iterable) {
-        if (iterable instanceof Collection) {
-            return ((Collection<?>) iterable).size();
+        if (iterable instanceof Collection<?> c) {
+            return c.size();
         }
 
         return IteratorUtil.size(iterable.iterator());

--- a/commons/util/src/main/java/net/automatalib/common/util/collection/PositiveIntSet.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/collection/PositiveIntSet.java
@@ -72,7 +72,7 @@ public class PositiveIntSet extends AbstractSet<Integer> {
 
     @Override
     public boolean contains(@Nullable Object o) {
-        return o instanceof Integer && containsInt((Integer) o);
+        return o instanceof Integer i && containsInt(i);
     }
 
     public boolean containsInt(int integer) {
@@ -102,7 +102,7 @@ public class PositiveIntSet extends AbstractSet<Integer> {
 
     @Override
     public boolean remove(@Nullable Object o) {
-        return o instanceof Integer && removeInt((Integer) o);
+        return o instanceof Integer i && removeInt(i);
     }
 
     public boolean removeInt(int integer) {

--- a/commons/util/src/main/java/net/automatalib/common/util/concurrent/ScalingThreadPoolExecutor.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/concurrent/ScalingThreadPoolExecutor.java
@@ -69,7 +69,6 @@ public final class ScalingThreadPoolExecutor extends ThreadPoolExecutor {
      * useful in combination with a {@link ForceEnqueuingHandler} that forcefully enqueues the scheduled task to this
      * (otherwise unbounded) queue.
      */
-    @SuppressWarnings("PMD.NonSerializableClass") // not publicly exposed
     private static final class ScalingLinkedBlockingQueue extends LinkedBlockingQueue<Runnable> {
 
         private ThreadPoolExecutor tpe;

--- a/commons/util/src/main/java/net/automatalib/common/util/exception/ExceptionUtil.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/exception/ExceptionUtil.java
@@ -33,11 +33,11 @@ public final class ExceptionUtil {
      *         the throwable to analyse
      */
     public static void throwIfUnchecked(@Nullable Throwable throwable) {
-        if (throwable instanceof RuntimeException) {
-            throw (RuntimeException) throwable;
+        if (throwable instanceof RuntimeException t) {
+            throw t;
         }
-        if (throwable instanceof Error) {
-            throw (Error) throwable;
+        if (throwable instanceof Error e) {
+            throw e;
         }
     }
 }

--- a/commons/util/src/main/java/net/automatalib/common/util/lib/LibLoader.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/lib/LibLoader.java
@@ -127,8 +127,6 @@ public final class LibLoader {
             case SYSTEM_ONLY:
                 loadSystemLibrary(name);
                 break;
-            default:
-                throw new IllegalStateException("Unknown policy " + policy);
         }
 
         loaded.add(name);

--- a/commons/util/src/main/java/net/automatalib/common/util/nid/DynamicList.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/nid/DynamicList.java
@@ -61,10 +61,9 @@ public class DynamicList<T extends MutableNumericID> extends AbstractList<T> {
 
     @SuppressWarnings("nullness") // setting 'null' is fine, because we also decrease the size
     public boolean remove(@Nullable Object elem, @Nullable IDChangeNotifier<T> tracker) {
-        if (!(elem instanceof MutableNumericID)) {
+        if (!(elem instanceof MutableNumericID idElem)) {
             return false;
         }
-        MutableNumericID idElem = (MutableNumericID) elem;
         int idx = idElem.getId();
         T myElem = safeGet(idx);
         if (elem != myElem) {

--- a/commons/util/src/main/java/net/automatalib/common/util/nid/IDChangeListener.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/nid/IDChangeListener.java
@@ -15,6 +15,7 @@
  */
 package net.automatalib.common.util.nid;
 
+@FunctionalInterface
 public interface IDChangeListener<T extends NumericID> {
 
     void idChanged(T obj, int newId, int oldId);

--- a/commons/util/src/main/java/net/automatalib/common/util/nid/NumericID.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/nid/NumericID.java
@@ -15,6 +15,7 @@
  */
 package net.automatalib.common.util.nid;
 
+@FunctionalInterface
 public interface NumericID {
 
     int getId();

--- a/commons/util/src/main/java/net/automatalib/common/util/process/InputStreamConsumer.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/process/InputStreamConsumer.java
@@ -26,6 +26,7 @@ import net.automatalib.common.util.IOUtil;
 /**
  * A utility interface for an input stream consumer that is allowed to throw {@link IOException}s.
  */
+@FunctionalInterface
 interface InputStreamConsumer {
 
     void consume(InputStream is) throws IOException;

--- a/commons/util/src/main/java/net/automatalib/common/util/ref/Ref.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/ref/Ref.java
@@ -27,6 +27,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @param <T>
  *         referent type
  */
+@FunctionalInterface
 public interface Ref<T> {
 
     /**

--- a/commons/util/src/main/java/net/automatalib/common/util/setting/SettingsSource.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/setting/SettingsSource.java
@@ -25,6 +25,7 @@ import net.automatalib.common.util.collection.IteratorUtil;
 /**
  * Utility interface to mark the source of a setting.
  */
+@FunctionalInterface
 public interface SettingsSource {
 
     /**

--- a/commons/util/src/main/java/net/automatalib/common/util/string/Printable.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/string/Printable.java
@@ -21,6 +21,7 @@ import java.io.IOException;
  * Interface that allows outputting to an {@link Appendable} (e.g., a {@link StringBuilder}) instead of simply using
  * {@link Object#toString()}.
  */
+@FunctionalInterface
 public interface Printable {
 
     static String toString(Printable p) {

--- a/commons/util/src/main/java/net/automatalib/common/util/string/StringUtil.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/string/StringUtil.java
@@ -225,8 +225,8 @@ public final class StringUtil {
     }
 
     public static void appendObject(Appendable a, @Nullable Object obj) throws IOException {
-        if (obj instanceof Printable) {
-            ((Printable) obj).print(a);
+        if (obj instanceof Printable p) {
+            p.print(a);
         } else {
             a.append(String.valueOf(obj));
         }

--- a/core/src/main/java/net/automatalib/alphabet/impl/AbstractSymbol.java
+++ b/core/src/main/java/net/automatalib/alphabet/impl/AbstractSymbol.java
@@ -30,15 +30,7 @@ public abstract class AbstractSymbol<S extends AbstractSymbol<S>> extends Abstra
 
     @Override
     public final boolean equals(@Nullable Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof Symbol)) {
-            return false;
-        }
-
-        final AbstractSymbol<?> that = (AbstractSymbol<?>) o;
-        return this.id == that.id;
+        return this == o || o instanceof Symbol<?> that && this.id == that.id;
     }
 
     @Override

--- a/core/src/main/java/net/automatalib/alphabet/impl/AbstractSymbol.java
+++ b/core/src/main/java/net/automatalib/alphabet/impl/AbstractSymbol.java
@@ -30,7 +30,7 @@ public abstract class AbstractSymbol<S extends AbstractSymbol<S>> extends Abstra
 
     @Override
     public final boolean equals(@Nullable Object o) {
-        return this == o || o instanceof Symbol<?> that && this.id == that.id;
+        return this == o || o instanceof AbstractSymbol<?> that && this.id == that.id;
     }
 
     @Override

--- a/core/src/main/java/net/automatalib/alphabet/impl/GrowingVPAlphabet.java
+++ b/core/src/main/java/net/automatalib/alphabet/impl/GrowingVPAlphabet.java
@@ -48,18 +48,11 @@ public class GrowingVPAlphabet<I> extends AbstractVPAlphabet<VPSym<I>> implement
     }
 
     public VPSym<I> addNewSymbol(I userObject, SymbolType type) {
-        final List<VPSym<I>> localList;
-        switch (type) {
-            case CALL:
-                localList = callSyms;
-                break;
-            case RETURN:
-                localList = returnSyms;
-                break;
-            default:
-                localList = internalSyms;
-                break;
-        }
+        final List<VPSym<I>> localList = switch (type) {
+            case CALL -> callSyms;
+            case INTERNAL -> internalSyms;
+            case RETURN -> returnSyms;
+        };
 
         final VPSym<I> vpSym = new VPSym<>(userObject, type, localList.size(), allSyms.size());
         allSyms.add(vpSym);

--- a/core/src/main/java/net/automatalib/automaton/base/AbstractCompact.java
+++ b/core/src/main/java/net/automatalib/automaton/base/AbstractCompact.java
@@ -424,6 +424,7 @@ public abstract class AbstractCompact<I, T, SP, TP> implements MutableAutomaton<
      * @param <T>
      *         the array type
      */
+    @FunctionalInterface
     private interface ArrayInitializer<T> {
 
         void setDefaultValue(T array, int idx);

--- a/core/src/main/java/net/automatalib/automaton/impl/CompactTransition.java
+++ b/core/src/main/java/net/automatalib/automaton/impl/CompactTransition.java
@@ -61,11 +61,8 @@ public class CompactTransition<TP> {
 
     @Override
     public boolean equals(@Nullable Object o) {
-        if (this == o) {
-            return true;
-        }
-
-        return o instanceof CompactTransition<?> that && memoryIdx == that.memoryIdx && succId == that.succId &&
+        return this == o ||
+               o instanceof CompactTransition<?> that && memoryIdx == that.memoryIdx && succId == that.succId &&
                Objects.equals(property, that.property);
     }
 

--- a/core/src/main/java/net/automatalib/automaton/impl/CompactTransition.java
+++ b/core/src/main/java/net/automatalib/automaton/impl/CompactTransition.java
@@ -64,12 +64,9 @@ public class CompactTransition<TP> {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof CompactTransition)) {
-            return false;
-        }
 
-        final CompactTransition<?> that = (CompactTransition<?>) o;
-        return memoryIdx == that.memoryIdx && succId == that.succId && Objects.equals(property, that.property);
+        return o instanceof CompactTransition<?> that && memoryIdx == that.memoryIdx && succId == that.succId &&
+               Objects.equals(property, that.property);
     }
 
     @Override

--- a/core/src/main/java/net/automatalib/automaton/transducer/probabilistic/impl/FastProbMealy.java
+++ b/core/src/main/java/net/automatalib/automaton/transducer/probabilistic/impl/FastProbMealy.java
@@ -42,13 +42,13 @@ public class FastProbMealy<I, O>
     @Override
     public void setTransitionOutput(MealyTransition<FastProbMealyState<O>, ProbabilisticOutput<O>> transition,
                                     O output) {
-        transition.setOutput(new ProbabilisticOutput<>(transition.getOutput().getProbability(), output));
+        transition.setOutput(new ProbabilisticOutput<>(transition.getOutput().probability(), output));
     }
 
     @Override
     public void setTransitionProbability(MealyTransition<FastProbMealyState<O>, ProbabilisticOutput<O>> transition,
                                          float probability) {
-        transition.setOutput(new ProbabilisticOutput<>(probability, transition.getOutput().getOutput()));
+        transition.setOutput(new ProbabilisticOutput<>(probability, transition.getOutput().output()));
     }
 
     @Override

--- a/core/src/main/java/net/automatalib/automaton/vpa/impl/AbstractSEVPA.java
+++ b/core/src/main/java/net/automatalib/automaton/vpa/impl/AbstractSEVPA.java
@@ -43,6 +43,7 @@ public abstract class AbstractSEVPA<L, I> implements SEVPA<L, I> {
     }
 
     @Override
+    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public @Nullable State<L> getTransition(State<L> state, I input) {
         final L loc = state.getLocation();
         final VPAlphabet.SymbolType type = alphabet.getSymbolType(input);

--- a/core/src/main/java/net/automatalib/automaton/vpa/impl/AbstractSEVPA.java
+++ b/core/src/main/java/net/automatalib/automaton/vpa/impl/AbstractSEVPA.java
@@ -43,36 +43,33 @@ public abstract class AbstractSEVPA<L, I> implements SEVPA<L, I> {
     }
 
     @Override
-    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public @Nullable State<L> getTransition(State<L> state, I input) {
         final L loc = state.getLocation();
         final VPAlphabet.SymbolType type = alphabet.getSymbolType(input);
-        switch (type) {
+        return switch (type) {
             case CALL:
                 final int newStackElem = encodeStackSym(loc, input);
-                return new State<>(getModuleEntry(input), StackContents.push(newStackElem, state.getStackContents()));
+                yield new State<>(getModuleEntry(input), StackContents.push(newStackElem, state.getStackContents()));
             case RETURN: {
                 final StackContents contents = state.getStackContents();
                 if (contents == null) {
-                    return null;
+                    yield null;
                 }
                 final int stackElem = contents.peek();
                 final L succ = getReturnSuccessor(loc, input, stackElem);
                 if (succ == null) {
-                    return null;
+                    yield null;
                 }
-                return new State<>(succ, contents.pop());
+                yield new State<>(succ, contents.pop());
             }
             case INTERNAL: {
                 final L succ = getInternalSuccessor(loc, input);
                 if (succ == null) {
-                    return null;
+                    yield null;
                 }
-                return new State<>(succ, state.getStackContents());
+                yield new State<>(succ, state.getStackContents());
             }
-            default:
-                throw new IllegalStateException("Unknown symbol type " + type);
-        }
+        };
     }
 
     @Override

--- a/core/src/main/java/net/automatalib/modelchecking/impl/InternalModelCheckerDelegator.java
+++ b/core/src/main/java/net/automatalib/modelchecking/impl/InternalModelCheckerDelegator.java
@@ -41,6 +41,7 @@ import net.automatalib.modelchecking.ModelCheckerLasso.MealyModelCheckerLasso;
  * @param <R>
  *         counterexample type
  */
+@FunctionalInterface
 interface InternalModelCheckerDelegator<MC extends ModelChecker<I, A, P, R>, I, A, P, R> {
 
     MC getModelChecker();

--- a/core/src/main/java/net/automatalib/ts/powerset/impl/FastPowersetState.java
+++ b/core/src/main/java/net/automatalib/ts/powerset/impl/FastPowersetState.java
@@ -49,11 +49,7 @@ public class FastPowersetState<S> extends AbstractSet<S> {
 
     @Override
     public final boolean equals(@Nullable Object o) {
-        if (this == o) {
-            return true;
-        }
-
-        return o instanceof FastPowersetState<?> that && bs.equals(that.bs);
+        return this == o || o instanceof FastPowersetState<?> that && bs.equals(that.bs);
     }
 
     @Override

--- a/core/src/main/java/net/automatalib/ts/powerset/impl/FastPowersetState.java
+++ b/core/src/main/java/net/automatalib/ts/powerset/impl/FastPowersetState.java
@@ -52,12 +52,8 @@ public class FastPowersetState<S> extends AbstractSet<S> {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof FastPowersetState)) {
-            return false;
-        }
 
-        final FastPowersetState<?> that = (FastPowersetState<?>) o;
-        return bs.equals(that.bs);
+        return o instanceof FastPowersetState<?> that && bs.equals(that.bs);
     }
 
     @Override

--- a/core/src/test/java/net/automatalib/alphabet/impl/basic/AbstractAlphabetTest.java
+++ b/core/src/test/java/net/automatalib/alphabet/impl/basic/AbstractAlphabetTest.java
@@ -152,8 +152,8 @@ public abstract class AbstractAlphabetTest<I, M extends Alphabet<I>> {
         final Comparator<I> r = alphabet.reversed();
         final Alphabet<I> reversed;
 
-        if (r instanceof Alphabet) {
-            reversed = (Alphabet<I>) r;
+        if (r instanceof Alphabet<I> rev) {
+            reversed = rev;
         } else {
             return;
         }

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -129,12 +129,34 @@ limitations under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
+                    <!-- For some reason (probably due to the testing dependencies) surefire auto-detects a JUnit runner.
+                         Since we use testng exclusively, help the plugin a little bit -->
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.maven.surefire</groupId>
+                            <artifactId>surefire-testng</artifactId>
+                            <version>${surefire-plugin.version}</version>
+                        </dependency>
+                    </dependencies>
                     <configuration>
                         <systemPropertyVariables>
-                            <awt.toolkit>com.github.caciocavallosilano.cacio.ctc.CTCToolkit</awt.toolkit>
-                            <java.awt.graphicsenv>com.github.caciocavallosilano.cacio.ctc.CTCGraphicsEnvironment</java.awt.graphicsenv>
                             <java.awt.headless>false</java.awt.headless>
                         </systemPropertyVariables>
+                        <argLine>
+                            --add-exports=java.desktop/java.awt=ALL-UNNAMED
+                            --add-exports=java.desktop/java.awt.peer=ALL-UNNAMED
+                            --add-exports=java.desktop/sun.awt.image=ALL-UNNAMED
+                            --add-exports=java.desktop/sun.java2d=ALL-UNNAMED
+                            --add-exports=java.desktop/java.awt.dnd.peer=ALL-UNNAMED
+                            --add-exports=java.desktop/sun.awt=ALL-UNNAMED
+                            --add-exports=java.desktop/sun.awt.event=ALL-UNNAMED
+                            --add-exports=java.desktop/sun.awt.datatransfer=ALL-UNNAMED
+                            --add-exports=java.base/sun.security.action=ALL-UNNAMED
+                            --add-opens=java.base/java.util=ALL-UNNAMED
+                            --add-opens=java.desktop/java.awt=ALL-UNNAMED
+                            --add-opens=java.desktop/sun.java2d=ALL-UNNAMED
+                            --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+                        </argLine>
                     </configuration>
                 </plugin>
             </plugins>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -143,6 +143,7 @@ limitations under the License.
                             <java.awt.headless>false</java.awt.headless>
                         </systemPropertyVariables>
                         <argLine>
+                            @{argLine}
                             --add-exports=java.desktop/java.awt=ALL-UNNAMED
                             --add-exports=java.desktop/java.awt.peer=ALL-UNNAMED
                             --add-exports=java.desktop/sun.awt.image=ALL-UNNAMED

--- a/examples/src/test/java/net/automatalib/example/ExamplesTest.java
+++ b/examples/src/test/java/net/automatalib/example/ExamplesTest.java
@@ -24,6 +24,7 @@ import java.lang.reflect.InvocationTargetException;
 
 import javax.swing.SwingUtilities;
 
+import com.github.caciocavallosilano.cacio.ctc.junit.CacioExtension;
 import net.automatalib.example.ads.ADSExample;
 import net.automatalib.example.brics.SimpleBricsExample;
 import net.automatalib.example.dot.DOTExample;
@@ -51,6 +52,9 @@ public class ExamplesTest {
     @BeforeClass
     public void setupAutoClose() {
         if (isJVMCompatible()) {
+            // hack: the static initializer of this class does the magic we want, so only invoke it on compatible JVMs
+            new CacioExtension();
+
             // As soon as we observe an event that indicates a new window, close it to prevent blocking the tests.
             Toolkit.getDefaultToolkit().addAWTEventListener(event -> {
                 final WindowEvent windowEvent = (WindowEvent) event;
@@ -151,12 +155,13 @@ public class ExamplesTest {
     }
 
     private static boolean isJVMCompatible() {
-        return Runtime.version().feature() == 11;
+        final int feature = Runtime.version().feature();
+        return feature == 17 || feature == 21;
     }
 
     private static void requireJVMCompatibility() {
         if (!isJVMCompatible()) {
-            throw new SkipException("The headless AWT environment currently only works with Java 11 or <=8");
+            throw new SkipException("The headless AWT environment only works with specific JVM versions");
         }
     }
 

--- a/incremental/src/main/java/net/automatalib/incremental/dfa/dag/StateSignature.java
+++ b/incremental/src/main/java/net/automatalib/incremental/dfa/dag/StateSignature.java
@@ -62,16 +62,8 @@ final class StateSignature {
 
     @Override
     public boolean equals(@Nullable Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!(obj instanceof StateSignature)) {
-            return false;
-        }
-
-        final StateSignature other = (StateSignature) obj;
-
-        return hashCode == other.hashCode && acceptance == other.acceptance &&
+        return this == obj ||
+               obj instanceof StateSignature other && hashCode == other.hashCode && acceptance == other.acceptance &&
                Objects.equals(successors, other.successors);
     }
 

--- a/incremental/src/main/java/net/automatalib/incremental/dfa/tree/IncrementalPCDFATreeBuilder.java
+++ b/incremental/src/main/java/net/automatalib/incremental/dfa/tree/IncrementalPCDFATreeBuilder.java
@@ -244,7 +244,6 @@ public class IncrementalPCDFATreeBuilder<I> extends IncrementalDFATreeBuilder<I>
         // if any of the successor of curr would have an acceptance value
         // of true, also curr would
         if (prev == null) {
-            assert curr == root;
             root.makeSink();
         } else {
             Node sink = getSink();

--- a/incremental/src/main/java/net/automatalib/incremental/mealy/dag/StateSignature.java
+++ b/incremental/src/main/java/net/automatalib/incremental/mealy/dag/StateSignature.java
@@ -61,16 +61,9 @@ final class StateSignature<O> {
 
     @Override
     public boolean equals(@Nullable Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!(obj instanceof StateSignature)) {
-            return false;
-        }
-
-        final StateSignature<?> other = (StateSignature<?>) obj;
-
-        return hashCode == other.hashCode && outputs.equals(other.outputs) && successors.equals(other.successors);
+        return this == obj ||
+               obj instanceof StateSignature<?> other && hashCode == other.hashCode && outputs.equals(other.outputs) &&
+               successors.equals(other.successors);
     }
 
 }

--- a/incremental/src/main/java/net/automatalib/incremental/moore/dag/StateSignature.java
+++ b/incremental/src/main/java/net/automatalib/incremental/moore/dag/StateSignature.java
@@ -63,17 +63,8 @@ final class StateSignature<O> {
 
     @Override
     public boolean equals(@Nullable Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!(obj instanceof StateSignature)) {
-            return false;
-        }
-
-        final StateSignature<?> other = (StateSignature<?>) obj;
-
-        return hashCode == other.hashCode && Objects.equals(output, other.output) &&
-               successors.equals(other.successors);
+        return this == obj || obj instanceof StateSignature<?> other && hashCode == other.hashCode &&
+                              Objects.equals(output, other.output) && successors.equals(other.successors);
     }
 
 }

--- a/modelchecking/ltsmin/src/main/java/net/automatalib/modelchecker/ltsmin/LTSminVersion.java
+++ b/modelchecking/ltsmin/src/main/java/net/automatalib/modelchecker/ltsmin/LTSminVersion.java
@@ -18,14 +18,20 @@ package net.automatalib.modelchecker.ltsmin;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A class for describing LTSmin version.
+ * A record for describing LTSmin versions.
+ *
+ * @param major
+ *         the major version
+ * @param minor
+ *         the minor version
+ * @param patch
+ *         the patch version
  */
-public final class LTSminVersion {
+public record LTSminVersion(int major, int minor, int patch) {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LTSminVersion.class);
 
@@ -33,14 +39,6 @@ public final class LTSminVersion {
      * The pattern for LTSmin versioning scheme: 'v[major].[minor].[patch][ignoredSuffix]'.
      */
     private static final Pattern VERSION_PATTERN = Pattern.compile("^v([0-9]+)\\.([0-9]+)\\.([0-9]+)");
-
-    private final int major, minor, patch;
-
-    private LTSminVersion(int major, int minor, int patch) {
-        this.major = major;
-        this.minor = minor;
-        this.patch = patch;
-    }
 
     /**
      * Returns an {@link LTSminVersion} instance described by the provided versions.
@@ -123,20 +121,5 @@ public final class LTSminVersion {
     @Override
     public String toString() {
         return String.format("v%d.%d.%d", major, minor, patch);
-    }
-
-    @Override
-    public boolean equals(@Nullable Object o) {
-        return this == o ||
-               o instanceof LTSminVersion that && major == that.major && minor == that.minor && patch == that.patch;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = 1;
-        result = 31 * result + Integer.hashCode(major);
-        result = 31 * result + Integer.hashCode(minor);
-        result = 31 * result + Integer.hashCode(patch);
-        return result;
     }
 }

--- a/modelchecking/ltsmin/src/main/java/net/automatalib/modelchecker/ltsmin/LTSminVersion.java
+++ b/modelchecking/ltsmin/src/main/java/net/automatalib/modelchecker/ltsmin/LTSminVersion.java
@@ -127,15 +127,8 @@ public final class LTSminVersion {
 
     @Override
     public boolean equals(@Nullable Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof LTSminVersion)) {
-            return false;
-        }
-
-        final LTSminVersion that = (LTSminVersion) o;
-        return major == that.major && minor == that.minor && patch == that.patch;
+        return this == o ||
+               o instanceof LTSminVersion that && major == that.major && minor == that.minor && patch == that.patch;
     }
 
     @Override

--- a/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/formula/DependencyGraph.java
+++ b/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/formula/DependencyGraph.java
@@ -95,11 +95,9 @@ public final class DependencyGraph<L, AP> {
         }
 
         /* Recurse into subtrees */
-        if (node instanceof AbstractUnaryFormulaNode) {
-            final AbstractUnaryFormulaNode<L, AP> unaryNode = (AbstractUnaryFormulaNode<L, AP>) node;
+        if (node instanceof AbstractUnaryFormulaNode<L, AP> unaryNode) {
             createEquationalBlocks(unaryNode.getChild(), newBlockNumber);
-        } else if (node instanceof AbstractBinaryFormulaNode) {
-            final AbstractBinaryFormulaNode<L, AP> binaryNode = (AbstractBinaryFormulaNode<L, AP>) node;
+        } else if (node instanceof AbstractBinaryFormulaNode<L, AP> binaryNode) {
             createEquationalBlocks(binaryNode.getLeftChild(), newBlockNumber);
             createEquationalBlocks(binaryNode.getRightChild(), newBlockNumber);
         }
@@ -107,14 +105,14 @@ public final class DependencyGraph<L, AP> {
 
     private int setVarNumbers(FormulaNode<L, AP> node, int varNumber) {
         /* Fill fixedPointVarMap */
-        if (node instanceof AbstractFixedPointFormulaNode) {
-            fixedPointVarMap.put(((AbstractFixedPointFormulaNode<L, AP>) node).getVariable(), node);
+        if (node instanceof AbstractFixedPointFormulaNode<L, AP> n) {
+            fixedPointVarMap.put(n.getVariable(), node);
         }
 
         /* Set node's variableNumber */
-        if (node instanceof VariableNode) {
+        if (node instanceof VariableNode<L, AP> n) {
             /* VariableNode has same variableNumber as the fixed point it references */
-            String refVariable = ((VariableNode<L, AP>) node).getVariable();
+            String refVariable = n.getVariable();
             @SuppressWarnings("nullness") // validated by the parser
             @NonNull FormulaNode<L, AP> refNode = fixedPointVarMap.get(refVariable);
             node.setVarNumber(refNode.getVarNumber());
@@ -130,11 +128,9 @@ public final class DependencyGraph<L, AP> {
         }
 
         /* Recurse into subtrees */
-        if (node instanceof AbstractUnaryFormulaNode) {
-            final AbstractUnaryFormulaNode<L, AP> unaryNode = (AbstractUnaryFormulaNode<L, AP>) node;
+        if (node instanceof AbstractUnaryFormulaNode<L, AP> unaryNode) {
             newVarNumber = setVarNumbers(unaryNode.getChild(), newVarNumber);
-        } else if (node instanceof AbstractBinaryFormulaNode) {
-            final AbstractBinaryFormulaNode<L, AP> binaryNode = (AbstractBinaryFormulaNode<L, AP>) node;
+        } else if (node instanceof AbstractBinaryFormulaNode<L, AP> binaryNode) {
             newVarNumber = setVarNumbers(binaryNode.getLeftChild(), newVarNumber);
             newVarNumber = setVarNumbers(binaryNode.getRightChild(), newVarNumber);
         }

--- a/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/formula/visitor/NNFVisitor.java
+++ b/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/formula/visitor/NNFVisitor.java
@@ -49,26 +49,26 @@ public class NNFVisitor<L, AP> {
     }
 
     private FormulaNode<L, AP> visit(FormulaNode<L, AP> node, boolean negate) {
-        if (node instanceof GfpNode) {
-            return visitGFPNode((GfpNode<L, AP>) node, negate);
-        } else if (node instanceof LfpNode) {
-            return visitLFPNode((LfpNode<L, AP>) node, negate);
-        } else if (node instanceof AndNode) {
-            return visitAndNode((AndNode<L, AP>) node, negate);
-        } else if (node instanceof AtomicNode) {
-            return visitAtomicNode((AtomicNode<L, AP>) node, negate);
-        } else if (node instanceof BoxNode) {
-            return visitBoxNode((BoxNode<L, AP>) node, negate);
-        } else if (node instanceof DiamondNode) {
-            return visitDiamondNode((DiamondNode<L, AP>) node, negate);
+        if (node instanceof GfpNode<L, AP> n) {
+            return visitGFPNode(n, negate);
+        } else if (node instanceof LfpNode<L, AP> n) {
+            return visitLFPNode(n, negate);
+        } else if (node instanceof AndNode<L, AP> n) {
+            return visitAndNode(n, negate);
+        } else if (node instanceof AtomicNode<L, AP> n) {
+            return visitAtomicNode(n, negate);
+        } else if (node instanceof BoxNode<L, AP> n) {
+            return visitBoxNode(n, negate);
+        } else if (node instanceof DiamondNode<L, AP> n) {
+            return visitDiamondNode(n, negate);
         } else if (node instanceof FalseNode) {
             return visitFalseNode(negate);
-        } else if (node instanceof VariableNode) {
-            return visitVariableNode((VariableNode<L, AP>) node, negate);
-        } else if (node instanceof NotNode) {
-            return visitNotNode((NotNode<L, AP>) node, negate);
-        } else if (node instanceof OrNode) {
-            return visitOrNode((OrNode<L, AP>) node, negate);
+        } else if (node instanceof VariableNode<L, AP> n) {
+            return visitVariableNode(n, negate);
+        } else if (node instanceof NotNode<L, AP> n) {
+            return visitNotNode(n, negate);
+        } else if (node instanceof OrNode<L, AP> n) {
+            return visitOrNode(n, negate);
         } else if (node instanceof TrueNode) {
             return visitTrueNode(negate);
         } else {

--- a/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/solver/AbstractDDSolver.java
+++ b/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/solver/AbstractDDSolver.java
@@ -360,23 +360,19 @@ abstract class AbstractDDSolver<T extends AbstractPropertyTransformer<T, L, AP>,
                 } else if (node instanceof BoxNode) {
                     /* End node has no outgoing edges */
                     satisfiedVariables.set(node.getVarNumber());
-                } else if (node instanceof AndNode) {
-                    final AndNode<L, AP> andNode = (AndNode<L, AP>) node;
+                } else if (node instanceof AndNode<L, AP> andNode) {
                     if (satisfiedVariables.get(andNode.getVarNumberLeft()) &&
                         satisfiedVariables.get(andNode.getVarNumberRight())) {
                         satisfiedVariables.set(andNode.getVarNumber());
                     }
-                } else if (node instanceof OrNode) {
-                    final OrNode<L, AP> orNode = (OrNode<L, AP>) node;
+                } else if (node instanceof OrNode<L, AP> orNode) {
                     if (satisfiedVariables.get(orNode.getVarNumberLeft()) ||
                         satisfiedVariables.get(orNode.getVarNumberRight())) {
                         satisfiedVariables.set(orNode.getVarNumber());
                     }
-                } else if (node instanceof NotNode) {
-                    final NotNode<L, AP> notNode = (NotNode<L, AP>) node;
-                    if (!satisfiedVariables.get(notNode.getVarNumberChild())) {
-                        satisfiedVariables.set(notNode.getVarNumber());
-                    }
+                } else if (node instanceof NotNode<L, AP> notNode &&
+                           !satisfiedVariables.get(notNode.getVarNumberChild())) {
+                    satisfiedVariables.set(notNode.getVarNumber());
                 }
             }
         }

--- a/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/solver/M3CSolver.java
+++ b/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/solver/M3CSolver.java
@@ -24,6 +24,7 @@ import net.automatalib.exception.FormatException;
  * @param <F>
  *         formula type
  */
+@FunctionalInterface
 public interface M3CSolver<F> {
 
     /**
@@ -46,6 +47,7 @@ public interface M3CSolver<F> {
      * @param <F>
      *         formula type
      */
+    @FunctionalInterface
     interface TypedM3CSolver<F> extends M3CSolver<F> {
 
         /**

--- a/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/solver/WitnessTreeExtractor.java
+++ b/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/solver/WitnessTreeExtractor.java
@@ -112,18 +112,18 @@ final class WitnessTreeExtractor<L, AP> {
 
         FormulaNode<L, AP> visitedFormula = queueElement.subformula;
 
-        if (visitedFormula instanceof LfpNode) {
-            visitedFormula = ((LfpNode<L, AP>) visitedFormula).getChild();
+        if (visitedFormula instanceof LfpNode<L, AP> f) {
+            visitedFormula = f.getChild();
         }
         if (visitedFormula instanceof VariableNode) {
             // fetch fresh child formula because in case of a VariableNode we want the whole formula again
             visitedFormula = dg.getFormulaNodes().get(visitedFormula.getVarNumber());
         }
 
-        if (visitedFormula instanceof OrNode) {
-            return exploreOR((OrNode<L, AP>) visitedFormula, queueElement);
-        } else if (visitedFormula instanceof DiamondNode) {
-            return exploreDia((DiamondNode<L, AP>) visitedFormula, queueElement);
+        if (visitedFormula instanceof OrNode<L, AP> f) {
+            return exploreOR(f, queueElement);
+        } else if (visitedFormula instanceof DiamondNode<L, AP> f) {
+            return exploreDia(f, queueElement);
         } else if (visitedFormula instanceof TrueNode) {
             return Collections.emptyList();
         } else if (visitedFormula instanceof AtomicNode) {

--- a/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/solver/WitnessTreeExtractor.java
+++ b/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/solver/WitnessTreeExtractor.java
@@ -141,8 +141,8 @@ final class WitnessTreeExtractor<L, AP> {
         final List<WitnessTreeState<?, L, ?, AP>> result = new ArrayList<>();
 
         if (queueElement.getSatisfiedSubformulae(dg, queueElement.state).get(leftFormula.getVarNumber())) {
-            result.add(new WitnessTreeState<>(queueElement.stack,
-                                              queueElement.unit,
+            result.add(new WitnessTreeState<>(queueElement.unit,
+                                              queueElement.stack,
                                               queueElement.state,
                                               leftFormula,
                                               queueElement.context,
@@ -151,8 +151,8 @@ final class WitnessTreeExtractor<L, AP> {
                                               wTree.size() - 1));
         }
         if (queueElement.getSatisfiedSubformulae(dg, queueElement.state).get(rightFormula.getVarNumber())) {
-            result.add(new WitnessTreeState<>(queueElement.stack,
-                                              queueElement.unit,
+            result.add(new WitnessTreeState<>(queueElement.unit,
+                                              queueElement.stack,
                                               queueElement.state,
                                               rightFormula,
                                               queueElement.context,
@@ -188,8 +188,8 @@ final class WitnessTreeExtractor<L, AP> {
 
             if (pmpg.getEdgeProperty(edge).isInternal()) {
                 if (queueElement.getSatisfiedSubformulae(dg, target).get(formula.getChild().getVarNumber())) {
-                    final WitnessTreeState<?, L, ?, AP> toAdd = new WitnessTreeState<>(queueElement.stack,
-                                                                                       queueElement.unit,
+                    final WitnessTreeState<?, L, ?, AP> toAdd = new WitnessTreeState<>(queueElement.unit,
+                                                                                       queueElement.stack,
                                                                                        target,
                                                                                        formula.getChild(),
                                                                                        queueElement.context,
@@ -234,8 +234,8 @@ final class WitnessTreeExtractor<L, AP> {
             if (pmpg.getEdgeProperty(edge).isInternal()) {
                 if (Objects.equals(label, moveLabel) &&
                     queueElement.getSatisfiedSubformulae(dg, target).get(formula.getChild().getVarNumber())) {
-                    final WitnessTreeState<?, L, ?, AP> toAdd = new WitnessTreeState<>(queueElement.stack,
-                                                                                       queueElement.unit,
+                    final WitnessTreeState<?, L, ?, AP> toAdd = new WitnessTreeState<>(queueElement.unit,
+                                                                                       queueElement.stack,
                                                                                        target,
                                                                                        formula.getChild(),
                                                                                        queueElement.context,
@@ -264,8 +264,8 @@ final class WitnessTreeExtractor<L, AP> {
                                                                                         L label,
                                                                                         N1 target,
                                                                                         DiamondNode<L, AP> formula) {
-        final WitnessTreeState<N1, L, ?, AP> succ = new WitnessTreeState<>(queueElement.stack,
-                                                                           queueElement.unit,
+        final WitnessTreeState<N1, L, ?, AP> succ = new WitnessTreeState<>(queueElement.unit,
+                                                                           queueElement.stack,
                                                                            target,
                                                                            queueElement.subformula,
                                                                            queueElement.context,
@@ -277,8 +277,8 @@ final class WitnessTreeExtractor<L, AP> {
         final @NonNull N2 initialNode = unit.pmpg.getInitialNode();
         final BitSet finalFormulae = queueElement.getSatisfiedSubformulae(dg, target);
 
-        WitnessTreeState<N2, L, E2, AP> result = new WitnessTreeState<>(succ,
-                                                                        unit,
+        WitnessTreeState<N2, L, E2, AP> result = new WitnessTreeState<>(unit,
+                                                                        succ,
                                                                         initialNode,
                                                                         formula,
                                                                         finalFormulae,
@@ -295,8 +295,8 @@ final class WitnessTreeExtractor<L, AP> {
 
     private <N1, N2, E1, E2> WitnessTreeState<N2, L, E2, AP> buildReturnNode(WitnessTreeState<N1, L, E1, AP> queueElement,
                                                                              WitnessTreeState<N2, L, E2, AP> prev) {
-        return new WitnessTreeState<>(prev.stack,
-                                      prev.unit,
+        return new WitnessTreeState<>(prev.unit,
+                                      prev.stack,
                                       prev.state,
                                       queueElement.subformula,
                                       prev.context,
@@ -309,6 +309,6 @@ final class WitnessTreeExtractor<L, AP> {
                                                                      FormulaNode<L, AP> formula) {
         @SuppressWarnings("nullness") // we have checked non-nullness of initial nodes in the model checker
         final @NonNull N initialNode = unit.pmpg.getInitialNode();
-        return new WitnessTreeState<>(null, unit, initialNode, formula, initialContext, "", null, -1);
+        return new WitnessTreeState<>(unit, null, initialNode, formula, initialContext, "", null, -1);
     }
 }

--- a/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/solver/WitnessTreeState.java
+++ b/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/solver/WitnessTreeState.java
@@ -36,8 +36,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class WitnessTreeState<N, L, E, AP> {
 
+    final AbstractDDSolver<?, L, AP>.WorkUnit<N, E> unit;
+
     public final @Nullable WitnessTreeState<?, L, ?, AP> stack;
-    public final AbstractDDSolver<?, L, AP>.WorkUnit<N, E> unit;
     public final L procedure;
     public final ProceduralModalProcessGraph<N, L, E, AP, ?> pmpg;
     public final N state;
@@ -48,9 +49,8 @@ public class WitnessTreeState<N, L, E, AP> {
     public final int parentId;
     public boolean isPartOfResult;
 
-    WitnessTreeState(@Nullable WitnessTreeState<?, L, ?, AP> stack,
-                     AbstractDDSolver<?, L, AP>.WorkUnit<N, E> unit,
-                     N state,
+    WitnessTreeState(AbstractDDSolver<?, L, AP>.WorkUnit<N, E> unit,
+                     @Nullable WitnessTreeState<?, L, ?, AP> stack, N state,
                      FormulaNode<L, AP> subformula,
                      BitSet context,
                      String displayLabel,

--- a/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/transformer/ADDTransformer.java
+++ b/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/transformer/ADDTransformer.java
@@ -246,15 +246,6 @@ public class ADDTransformer<L, AP> extends AbstractPropertyTransformer<ADDTransf
 
     @Override
     public boolean equals(@Nullable Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        final ADDTransformer<?, ?> that = (ADDTransformer<?, ?>) o;
-
-        return Objects.equals(this.add, that.add);
+        return this == o || o instanceof ADDTransformer<?, ?> that && Objects.equals(this.add, that.add);
     }
 }

--- a/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/transformer/ADDTransformer.java
+++ b/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/transformer/ADDTransformer.java
@@ -116,8 +116,7 @@ public class ADDTransformer<L, AP> extends AbstractPropertyTransformer<ADDTransf
         for (FormulaNode<L, AP> node : dependGraph.getFormulaNodes()) {
             final boolean[] terminal = new boolean[dependGraph.getNumVariables()];
             final XDD<BooleanVector> falseDD = xddManager.constant(new BooleanVector(terminal));
-            if (node instanceof AbstractModalFormulaNode) {
-                final AbstractModalFormulaNode<L, AP> modalNode = (AbstractModalFormulaNode<L, AP>) node;
+            if (node instanceof AbstractModalFormulaNode<L, AP> modalNode) {
                 final L action = modalNode.getAction();
                 if ((action == null || action.equals(edgeLabel)) &&
                     (!(modalNode instanceof DiamondNode) || edgeProperty.isMust())) {

--- a/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/transformer/BDDTransformer.java
+++ b/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/transformer/BDDTransformer.java
@@ -107,8 +107,7 @@ public class BDDTransformer<L, AP> extends AbstractPropertyTransformer<BDDTransf
         this(bddManager, new BDD[dependencyGraph.getNumVariables()], edgeProperty.isMust());
         for (FormulaNode<L, AP> node : dependencyGraph.getFormulaNodes()) {
             int xi = node.getVarNumber();
-            if (node instanceof AbstractModalFormulaNode) {
-                final AbstractModalFormulaNode<L, AP> modalNode = (AbstractModalFormulaNode<L, AP>) node;
+            if (node instanceof AbstractModalFormulaNode<L, AP> modalNode) {
                 final L action = modalNode.getAction();
                 /* action matches edgeLabel AND (node instanceof DiamondNode => edge.isMust) */
                 if ((action == null || action.equals(edgeLabel)) &&
@@ -185,21 +184,18 @@ public class BDDTransformer<L, AP> extends AbstractPropertyTransformer<BDDTransf
             result = andBddList(compositions, varIdx);
         } else if (node instanceof DiamondNode) {
             result = orBddList(compositions, varIdx);
-        } else if (node instanceof AndNode) {
-            final AndNode<L, AP> andNode = (AndNode<L, AP>) node;
+        } else if (node instanceof AndNode<L, AP> andNode) {
             result = updatedBDDs[andNode.getVarNumberLeft()].and(updatedBDDs[andNode.getVarNumberRight()]);
-        } else if (node instanceof OrNode) {
-            final OrNode<L, AP> orNode = (OrNode<L, AP>) node;
+        } else if (node instanceof OrNode<L, AP> orNode) {
             result = updatedBDDs[orNode.getVarNumberLeft()].or(updatedBDDs[orNode.getVarNumberRight()]);
         } else if (node instanceof TrueNode) {
             result = bddManager.readOne();
         } else if (node instanceof FalseNode) {
             result = bddManager.readLogicZero();
-        } else if (node instanceof NotNode) {
-            final NotNode<L, AP> notNode = (NotNode<L, AP>) node;
+        } else if (node instanceof NotNode<L, AP> notNode) {
             result = bdds[notNode.getVarNumberChild()].not();
-        } else if (node instanceof AtomicNode) {
-            final AP atomicProp = ((AtomicNode<L, AP>) node).getProposition();
+        } else if (node instanceof AtomicNode<L, AP> atomicNode) {
+            final AP atomicProp = atomicNode.getProposition();
             if (atomicPropositions.contains(atomicProp)) {
                 result = bddManager.readOne();
             } else {

--- a/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/transformer/BDDTransformer.java
+++ b/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/transformer/BDDTransformer.java
@@ -248,15 +248,6 @@ public class BDDTransformer<L, AP> extends AbstractPropertyTransformer<BDDTransf
 
     @Override
     public boolean equals(@Nullable Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        final BDDTransformer<?, ?> that = (BDDTransformer<?, ?>) o;
-
-        return Arrays.equals(this.bdds, that.bdds);
+        return this == o || o instanceof BDDTransformer<?, ?> that && Arrays.equals(this.bdds, that.bdds);
     }
 }

--- a/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/transformer/DiamondOperation.java
+++ b/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/transformer/DiamondOperation.java
@@ -55,8 +55,7 @@ public class DiamondOperation<AP> implements BinaryOperator<BooleanVector> {
                 result[currentVar] = result[currentVar] && right.data()[currentVar];
             } else if (node instanceof DiamondNode) {
                 result[currentVar] = result[currentVar] || right.data()[currentVar];
-            } else if (node instanceof AbstractBinaryFormulaNode) {
-                final AbstractBinaryFormulaNode<?, ?> binaryNode = (AbstractBinaryFormulaNode<?, ?>) node;
+            } else if (node instanceof AbstractBinaryFormulaNode<?, ?> binaryNode) {
                 final int xj1 = binaryNode.getVarNumberLeft();
                 final int xj2 = binaryNode.getVarNumberRight();
                 if (binaryNode instanceof AndNode) {
@@ -68,11 +67,10 @@ public class DiamondOperation<AP> implements BinaryOperator<BooleanVector> {
                 result[currentVar] = true;
             } else if (node instanceof FalseNode) {
                 result[currentVar] = false;
-            } else if (node instanceof NotNode) {
-                final NotNode<?, ?> notNode = (NotNode<?, ?>) node;
+            } else if (node instanceof NotNode<?, ?> notNode) {
                 result[currentVar] = !result[notNode.getVarNumberChild()];
-            } else if (node instanceof AtomicNode) {
-                final AP prop = ((AtomicNode<?, AP>) node).getProposition();
+            } else if (node instanceof AtomicNode<?, AP> atomicNode) {
+                final AP prop = atomicNode.getProposition();
                 result[currentVar] = atomicPropositions.contains(prop);
             } else {
                 throw new IllegalArgumentException("The current equational block contains an unsupported formula type.");

--- a/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/transformer/DiamondOperationDeadlock.java
+++ b/modelchecking/m3c/src/main/java/net/automatalib/modelchecker/m3c/transformer/DiamondOperationDeadlock.java
@@ -55,8 +55,7 @@ public class DiamondOperationDeadlock<AP> implements UnaryOperator<BooleanVector
                 result[currentVar] = true;
             } else if (node instanceof DiamondNode) {
                 result[currentVar] = false;
-            } else if (node instanceof AbstractBinaryFormulaNode) {
-                final AbstractBinaryFormulaNode<?, ?> binaryNode = (AbstractBinaryFormulaNode<?, ?>) node;
+            } else if (node instanceof AbstractBinaryFormulaNode<?, ?> binaryNode) {
                 final int xj1 = binaryNode.getVarNumberLeft();
                 final int xj2 = binaryNode.getVarNumberRight();
                 if (binaryNode instanceof AndNode) {
@@ -68,11 +67,10 @@ public class DiamondOperationDeadlock<AP> implements UnaryOperator<BooleanVector
                 result[currentVar] = true;
             } else if (node instanceof FalseNode) {
                 result[currentVar] = false;
-            } else if (node instanceof NotNode) {
-                final NotNode<?, ?> notNode = (NotNode<?, ?>) node;
+            } else if (node instanceof NotNode<?, ?> notNode) {
                 result[currentVar] = !result[notNode.getVarNumberChild()];
-            } else if (node instanceof AtomicNode) {
-                final AP prop = ((AtomicNode<?, AP>) node).getProposition();
+            } else if (node instanceof AtomicNode<?, AP> atomicNode) {
+                final AP prop = atomicNode.getProposition();
                 result[currentVar] = atomicPropositions.contains(prop);
             } else {
                 throw new IllegalArgumentException("The current equational block contains an unsupported formula type.");

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@ limitations under the License.
         <scm-publish-plugin.version>3.3.0</scm-publish-plugin.version>
         <site-plugin.version>3.21.0</site-plugin.version>
         <source-plugin.version>3.3.1</source-plugin.version>
-        <spotbugs-plugin.version>4.9.7.0</spotbugs-plugin.version>
+        <spotbugs-plugin.version>4.9.8.1</spotbugs-plugin.version>
         <surefire-plugin.version>3.5.2</surefire-plugin.version>
         <tidy-pom.version>1.3.0</tidy-pom.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,9 @@ limitations under the License.
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.testSource>17</maven.compiler.testSource>
+        <maven.compiler.testTarget>17</maven.compiler.testTarget>
+        <maven.compiler.testRelease>17</maven.compiler.testRelease>
         <argLine /> <!-- compatibility for property expansion in surefire-plugin -->
 
         <!-- plugin versions -->
@@ -206,7 +209,7 @@ limitations under the License.
         <info-reports-plugin.version>3.8.0</info-reports-plugin.version>
         <install-plugin.version>3.1.3</install-plugin.version>
         <invoker-plugin.version>3.9.0</invoker-plugin.version>
-        <jacoco-plugin.version>0.8.12</jacoco-plugin.version>
+        <jacoco-plugin.version>0.8.13</jacoco-plugin.version>
         <jar-plugin.version>3.4.2</jar-plugin.version>
         <javacc-plugin.version>3.0.1</javacc-plugin.version>
         <javadoc-plugin.version>3.11.2</javadoc-plugin.version>
@@ -226,7 +229,7 @@ limitations under the License.
         <assertj.version>3.17.1</assertj.version>
         <brics-automaton.version>1.12-4</brics-automaton.version>
         <build-tools.version>0.1.1</build-tools.version>
-        <cacio.version>1.11.1</cacio.version>
+        <cacio.version>1.18</cacio.version>
         <checkerframework.version>3.48.3</checkerframework.version>
         <checkstyle.version>10.21.1</checkstyle.version>
         <extra-enforcer-rules.version>1.9.0</extra-enforcer-rules.version>
@@ -236,7 +239,7 @@ limitations under the License.
         <jung.version>2.1.1</jung.version>
         <logback.version>1.5.15</logback.version>
         <metainf-services.version>1.11</metainf-services.version>
-        <mockito.version>5.14.2</mockito.version>
+        <mockito.version>5.20.0</mockito.version>
         <slf4j.version>2.0.16</slf4j.version>
         <testng.version>7.10.2</testng.version>
 
@@ -1155,24 +1158,6 @@ limitations under the License.
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>jdk17-compat</id>
-            <activation>
-                <jdk>17</jdk>
-            </activation>
-            <properties>
-                <cacio.version>1.17.3</cacio.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>jdk21-compat</id>
-            <activation>
-                <jdk>21</jdk>
-            </activation>
-            <properties>
-                <cacio.version>1.18</cacio.version>
-            </properties>
         </profile>
         <profile>
             <!-- define module in a profile so that we can disable it during a release -->

--- a/pom.xml
+++ b/pom.xml
@@ -185,12 +185,9 @@ limitations under the License.
         <!-- general config -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.release>11</maven.compiler.release>
-        <maven.compiler.testSource>17</maven.compiler.testSource>
-        <maven.compiler.testTarget>17</maven.compiler.testTarget>
-        <maven.compiler.testRelease>17</maven.compiler.testRelease>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <argLine /> <!-- compatibility for property expansion in surefire-plugin -->
 
         <!-- plugin versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -214,13 +214,13 @@ limitations under the License.
         <javacc-plugin.version>3.0.1</javacc-plugin.version>
         <javadoc-plugin.version>3.11.2</javadoc-plugin.version>
         <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
-        <pmd-plugin.version>3.26.0</pmd-plugin.version>
+        <pmd-plugin.version>3.28.0</pmd-plugin.version>
         <release-plugin.version>3.1.0</release-plugin.version>
         <resources-plugin.version>3.3.1</resources-plugin.version>
         <scm-publish-plugin.version>3.3.0</scm-publish-plugin.version>
         <site-plugin.version>3.21.0</site-plugin.version>
         <source-plugin.version>3.3.1</source-plugin.version>
-        <spotbugs-plugin.version>4.8.6.6</spotbugs-plugin.version>
+        <spotbugs-plugin.version>4.9.7.0</spotbugs-plugin.version>
         <surefire-plugin.version>3.5.2</surefire-plugin.version>
         <tidy-pom.version>1.3.0</tidy-pom.version>
 
@@ -232,7 +232,7 @@ limitations under the License.
         <cacio.version>1.18</cacio.version>
         <checkerframework.version>3.48.3</checkerframework.version>
         <checkstyle.version>10.21.1</checkstyle.version>
-        <extra-enforcer-rules.version>1.9.0</extra-enforcer-rules.version>
+        <extra-enforcer-rules.version>1.10.0</extra-enforcer-rules.version>
         <guava.version>33.4.0-jre</guava.version>
         <graphviz-awt-shapes.version>0.0.1</graphviz-awt-shapes.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>

--- a/serialization/aut/src/main/java/net/automatalib/serialization/aut/InternalAUTParser.java
+++ b/serialization/aut/src/main/java/net/automatalib/serialization/aut/InternalAUTParser.java
@@ -209,7 +209,7 @@ class InternalAUTParser<I, T, @Nullable TP, A extends MutableAutomaton<Integer, 
             sym = currentLineContent[currentPos];
         }
 
-        if (sb.length() == 0) {
+        if (sb.isEmpty()) {
             throw new FormatException(buildErrorMessage("Expected a positive number"));
         }
 

--- a/serialization/dot/src/main/java/net/automatalib/serialization/dot/DOTInputModelDeserializer.java
+++ b/serialization/dot/src/main/java/net/automatalib/serialization/dot/DOTInputModelDeserializer.java
@@ -37,6 +37,7 @@ import net.automatalib.ts.simple.SimpleTS;
  * @param <M>
  *         the type of objects implementing classes can deserialize
  */
+@FunctionalInterface
 public interface DOTInputModelDeserializer<S, I, M extends SimpleTS<S, I>> extends InputModelDeserializer<I, M> {
 
     @Override

--- a/serialization/dot/src/main/java/net/automatalib/serialization/dot/GraphDOT.java
+++ b/serialization/dot/src/main/java/net/automatalib/serialization/dot/GraphDOT.java
@@ -285,8 +285,8 @@ public final class GraphDOT {
         writeRawBody(graph, a, dotHelper, directed, "");
         writeRawFooter(a);
 
-        if (a instanceof Flushable) {
-            ((Flushable) a).flush();
+        if (a instanceof Flushable f) {
+            f.flush();
         }
     }
 
@@ -458,8 +458,8 @@ public final class GraphDOT {
     }
 
     public static <N, E> DOTVisualizationHelper<N, E> toDOTVisualizationHelper(VisualizationHelper<N, E> helper) {
-        if (helper instanceof DOTVisualizationHelper) {
-            return (DOTVisualizationHelper<N, E>) helper;
+        if (helper instanceof DOTVisualizationHelper<N, E> h) {
+            return h;
         }
 
         return new DefaultDOTVisualizationHelper<>(helper);

--- a/serialization/fsm/src/main/java/net/automatalib/serialization/fsm/parser/AbstractFSMParser.java
+++ b/serialization/fsm/src/main/java/net/automatalib/serialization/fsm/parser/AbstractFSMParser.java
@@ -257,7 +257,6 @@ public abstract class AbstractFSMParser<I> {
                     parseTransition(streamTokenizer);
                     break;
                 }
-                default: throw new AssertionError();
             }
             while (streamTokenizer.nextToken() != StreamTokenizer.TT_EOL) {
                 // consume all tokens until EOL is reached

--- a/serialization/fsm/src/main/java/net/automatalib/serialization/fsm/parser/FSM2DFAParser.java
+++ b/serialization/fsm/src/main/java/net/automatalib/serialization/fsm/parser/FSM2DFAParser.java
@@ -22,6 +22,7 @@ import java.io.StreamTokenizer;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.function.Function;
@@ -320,13 +321,8 @@ public final class FSM2DFAParser<I, A extends MutableDFA<Integer, I>> extends Ab
 
         parse(reader);
 
-        final Alphabet<I> alphabet;
-
-        if (targetInputs != null) {
-            alphabet = Alphabets.fromCollection(targetInputs);
-        } else {
-            alphabet = Alphabets.fromCollection(getInputs());
-        }
+        final Alphabet<I> alphabet =
+                Alphabets.fromCollection(Objects.requireNonNullElseGet(targetInputs, this::getInputs));
 
         final A dfa = creator.createAutomaton(alphabet);
 

--- a/serialization/fsm/src/main/java/net/automatalib/serialization/fsm/parser/FSM2MealyParserIO.java
+++ b/serialization/fsm/src/main/java/net/automatalib/serialization/fsm/parser/FSM2MealyParserIO.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.io.StreamTokenizer;
 import java.util.Collection;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import net.automatalib.automaton.AutomatonCreator;
 import net.automatalib.automaton.transducer.MealyMachine;
@@ -135,7 +134,7 @@ public final class FSM2MealyParserIO<I, O, A extends MutableMealyMachine<Integer
         // Only if no states are defined we add all from the transitions we found.
         // This is necessary because states are not necessarily defined in FSMs.
         if (getStates().isEmpty()) {
-            getStates().addAll(getTransitions().keySet().stream().map(Pair::getFirst).collect(Collectors.toList()));
+            getStates().addAll(getTransitions().keySet().stream().map(Pair::getFirst).toList());
         }
     }
 

--- a/serialization/learnlibv2/src/test/java/net/automatalib/serialization/learnlibv2/LearnLibV2SerializationTest.java
+++ b/serialization/learnlibv2/src/test/java/net/automatalib/serialization/learnlibv2/LearnLibV2SerializationTest.java
@@ -17,7 +17,6 @@ package net.automatalib.serialization.learnlibv2;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Random;
 
@@ -44,7 +43,7 @@ public class LearnLibV2SerializationTest {
     }
 
     @Test
-    public void outputEqualsInputTest() throws IOException {
+    public void outputEqualsInputTest() {
         final Alphabet<Integer> alphabet = this.automaton.getInputAlphabet();
         final InputModelData<Integer, DFA<Integer, Integer>> deserializedData = writeAndRead(this.automaton, alphabet);
 
@@ -68,7 +67,7 @@ public class LearnLibV2SerializationTest {
     }
 
     @Test
-    public void doNotCloseInputOutputStreamTest() throws IOException {
+    public void doNotCloseInputOutputStreamTest() {
         final Alphabet<Integer> alphabet = this.automaton.getInputAlphabet();
         LearnLibV2Serialization<Integer> serializer = LearnLibV2Serialization.getInstance();
 
@@ -80,7 +79,7 @@ public class LearnLibV2SerializationTest {
     }
 
     private InputModelData<Integer, DFA<Integer, Integer>> writeAndRead(DFA<Integer, Integer> automaton,
-                                                                        Alphabet<Integer> alphabet) throws IOException {
+                                                                        Alphabet<Integer> alphabet) {
         LearnLibV2Serialization<Integer> serializer = LearnLibV2Serialization.getInstance();
 
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/serialization/taf/src/main/java/net/automatalib/serialization/taf/parser/TAFAnyParser.java
+++ b/serialization/taf/src/main/java/net/automatalib/serialization/taf/parser/TAFAnyParser.java
@@ -31,6 +31,7 @@ import net.automatalib.serialization.InputModelDeserializer;
 final class TAFAnyParser implements InputModelDeserializer<String, FiniteAlphabetAutomaton<?, String, ?>> {
 
     @Override
+    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public InputModelData<String, FiniteAlphabetAutomaton<?, String, ?>> readModel(InputStream is) throws IOException, FormatException {
 
         try (Reader r = IOUtil.asNonClosingUTF8Reader(is)) {

--- a/serialization/taf/src/main/java/net/automatalib/serialization/taf/parser/TAFAnyParser.java
+++ b/serialization/taf/src/main/java/net/automatalib/serialization/taf/parser/TAFAnyParser.java
@@ -31,7 +31,6 @@ import net.automatalib.serialization.InputModelDeserializer;
 final class TAFAnyParser implements InputModelDeserializer<String, FiniteAlphabetAutomaton<?, String, ?>> {
 
     @Override
-    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public InputModelData<String, FiniteAlphabetAutomaton<?, String, ?>> readModel(InputStream is) throws IOException, FormatException {
 
         try (Reader r = IOUtil.asNonClosingUTF8Reader(is)) {
@@ -39,22 +38,20 @@ final class TAFAnyParser implements InputModelDeserializer<String, FiniteAlphabe
 
             try {
                 final Type type = parser.type();
-                switch (type) {
+                return switch (type) {
                     case DFA: {
                         final DefaultTAFBuilderDFA<CompactDFA<String>, Integer> builder =
                                 new DefaultTAFBuilderDFA<>(parser, new CompactDFA.Creator<>());
                         parser.dfaBody(builder);
-                        return new InputModelData<>(builder.finish(), builder.getAlphabet());
+                        yield new InputModelData<>(builder.finish(), builder.getAlphabet());
                     }
                     case MEALY: {
                         final DefaultTAFBuilderMealy<CompactMealy<String, String>, Integer, CompactTransition<String>>
                                 builder = new DefaultTAFBuilderMealy<>(parser, new CompactMealy.Creator<>());
                         parser.mealyBody(builder);
-                        return new InputModelData<>(builder.finish(), builder.getAlphabet());
+                        yield new InputModelData<>(builder.finish(), builder.getAlphabet());
                     }
-                    default:
-                        throw new IllegalStateException("Unknown type " + type);
-                }
+                };
             } catch (ParseException ex) {
                 throw new FormatException(ex);
             }

--- a/util/src/main/java/net/automatalib/util/automaton/conformance/StrictPriorityQueue.java
+++ b/util/src/main/java/net/automatalib/util/automaton/conformance/StrictPriorityQueue.java
@@ -75,7 +75,6 @@ class StrictPriorityQueue<E> extends AbstractQueue<E> {
      * @return {@code true} if the element has been inserted, {@code false} if it has been merged with an existing
      * element.
      */
-    @SuppressWarnings("PMD.AvoidArrayLoops") // we move non-contiguous elements that can't be batched
     private boolean upHeap() {
         int currIdx = size - 1;
         E elem = storage.get(currIdx);
@@ -184,6 +183,7 @@ class StrictPriorityQueue<E> extends AbstractQueue<E> {
      * @param <E>
      *         element type
      */
+    @FunctionalInterface
     public interface MergeOperation<E> {
 
         /**

--- a/util/src/main/java/net/automatalib/util/automaton/copy/AutomatonCopyMethod.java
+++ b/util/src/main/java/net/automatalib/util/automaton/copy/AutomatonCopyMethod.java
@@ -24,6 +24,7 @@ import net.automatalib.automaton.MutableAutomaton;
 import net.automatalib.ts.TransitionPredicate;
 import net.automatalib.util.traversal.TraversalOrder;
 
+@FunctionalInterface
 public interface AutomatonCopyMethod {
 
     AutomatonCopyMethod STATE_BY_STATE = PlainAutomatonCopy::new;

--- a/util/src/main/java/net/automatalib/util/automaton/procedural/SPAs.java
+++ b/util/src/main/java/net/automatalib/util/automaton/procedural/SPAs.java
@@ -303,11 +303,11 @@ public final class SPAs {
                                     final WordBuilder<I> wb = new WordBuilder<>(init2s.size() + succ2acc.size() + 1);
 
                                     for (TransitionEdge<I, S> t : init2s) {
-                                        wb.append(t.getInput());
+                                        wb.append(t.input());
                                     }
                                     wb.append(i);
                                     for (TransitionEdge<I, S> t : succ2acc) {
-                                        wb.append(t.getInput());
+                                        wb.append(t.input());
                                     }
 
                                     result.add(wb.toWord());

--- a/util/src/main/java/net/automatalib/util/automaton/vpa/SPAConverter.java
+++ b/util/src/main/java/net/automatalib/util/automaton/vpa/SPAConverter.java
@@ -49,17 +49,17 @@ import net.automatalib.word.Word;
 import net.automatalib.word.WordBuilder;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-final class SPAConverter {
+public final class SPAConverter {
 
     private SPAConverter() {
         // prevent initialization
     }
 
-    public static <L, AI, CI> ConversionResult<AI, CI> convert(OneSEVPA<L, AI> sevpa,
-                                                               VPAlphabet<AI> alphabet,
-                                                               CI mainProcedure,
-                                                               SymbolMapper<AI, CI> symbolMapper,
-                                                               boolean minimize) {
+    static <L, AI, CI> ConversionResult<AI, CI> convert(OneSEVPA<L, AI> sevpa,
+                                                        VPAlphabet<AI> alphabet,
+                                                        CI mainProcedure,
+                                                        SymbolMapper<AI, CI> symbolMapper,
+                                                        boolean minimize) {
         if (alphabet.getNumReturns() != 1) {
             throw new IllegalArgumentException("Currently only single return symbols are supported.");
         }

--- a/util/src/main/java/net/automatalib/util/graph/Graphs.java
+++ b/util/src/main/java/net/automatalib/util/graph/Graphs.java
@@ -43,8 +43,7 @@ public final class Graphs {
     private Graphs() {}
 
     public static <N, E> Mapping<N, Collection<E>> incomingEdges(Graph<N, E> graph) {
-        if (graph instanceof BidirectionalGraph) {
-            final BidirectionalGraph<N, E> bdGraph = (BidirectionalGraph<N, E>) graph;
+        if (graph instanceof BidirectionalGraph<N, E> bdGraph) {
             return bdGraph::getIncomingEdges;
         }
 

--- a/util/src/main/java/net/automatalib/util/graph/scc/SCCListener.java
+++ b/util/src/main/java/net/automatalib/util/graph/scc/SCCListener.java
@@ -17,6 +17,7 @@ package net.automatalib.util.graph.scc;
 
 import java.util.Collection;
 
+@FunctionalInterface
 public interface SCCListener<N> {
 
     void foundSCC(Collection<? extends N> scc);

--- a/util/src/main/java/net/automatalib/util/graph/sssp/DijkstraSSSP.java
+++ b/util/src/main/java/net/automatalib/util/graph/sssp/DijkstraSSSP.java
@@ -180,6 +180,7 @@ public class DijkstraSSSP<N, E> implements SSSPResult<N, E> {
     /**
      * Internal data record. Note: this class has a natural ordering that is inconsistent with equals.
      */
+    @SuppressWarnings("PMD.OverrideBothEqualsAndHashCodeOnComparable")
     private static final class Record<N, E> implements Comparable<Record<N, E>> {
 
         public final N node;

--- a/util/src/main/java/net/automatalib/util/graph/traversal/GraphTraversal.java
+++ b/util/src/main/java/net/automatalib/util/graph/traversal/GraphTraversal.java
@@ -551,20 +551,15 @@ public final class GraphTraversal {
      *
      * @return {@code false} if the number of explored nodes reached {@code limit}, {@code true} otherwise
      */
-    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public static <N, E, D> boolean traverse(TraversalOrder order,
                                              IndefiniteGraph<N, E> graph,
                                              int limit,
                                              Collection<? extends N> initialNodes,
                                              GraphTraversalVisitor<N, E, D> visitor) {
-        switch (order) {
-            case BREADTH_FIRST:
-                return breadthFirst(graph, limit, initialNodes, visitor);
-            case DEPTH_FIRST:
-                return depthFirst(graph, limit, initialNodes, visitor);
-            default:
-                throw new IllegalArgumentException("Unknown traversal order " + order);
-        }
+        return switch (order) {
+            case BREADTH_FIRST -> breadthFirst(graph, limit, initialNodes, visitor);
+            case DEPTH_FIRST -> depthFirst(graph, limit, initialNodes, visitor);
+        };
     }
 
 }

--- a/util/src/main/java/net/automatalib/util/graph/traversal/GraphTraversal.java
+++ b/util/src/main/java/net/automatalib/util/graph/traversal/GraphTraversal.java
@@ -157,9 +157,6 @@ public final class GraphTraversal {
                         bfsQueue.add(new BFRecord<>(init, dataHolder.value));
                         nodeCount++;
                     }
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unknown action " + act);
             }
         }
 
@@ -198,9 +195,6 @@ public final class GraphTraversal {
                             bfsQueue.offer(new BFRecord<>(tgtNode, dataHolder.value));
                             nodeCount++;
                         }
-                        break;
-                    default:
-                        throw new IllegalArgumentException("Unknown action " + act);
                 }
             }
 
@@ -366,9 +360,6 @@ public final class GraphTraversal {
                         dfsStack.push(new DFRecord<>(init, dataHolder.value));
                         nodeCount++;
                     }
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unknown action " + act);
             }
         }
 
@@ -416,9 +407,6 @@ public final class GraphTraversal {
                         dfsStack.push(new DFRecord<>(tgt, data));
                         nodeCount++;
                     }
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unknown action " + act);
             }
         }
 
@@ -563,6 +551,7 @@ public final class GraphTraversal {
      *
      * @return {@code false} if the number of explored nodes reached {@code limit}, {@code true} otherwise
      */
+    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public static <N, E, D> boolean traverse(TraversalOrder order,
                                              IndefiniteGraph<N, E> graph,
                                              int limit,

--- a/util/src/main/java/net/automatalib/util/partitionrefinement/StateSignature.java
+++ b/util/src/main/java/net/automatalib/util/partitionrefinement/StateSignature.java
@@ -103,15 +103,7 @@ public final class StateSignature {
 
     @Override
     public boolean equals(@Nullable Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof StateSignature)) {
-            return false;
-        }
-
-        final StateSignature that = (StateSignature) o;
-        return Arrays.equals(properties, that.properties);
+        return this == o || o instanceof StateSignature that && Arrays.equals(properties, that.properties);
     }
 
     @Override

--- a/util/src/main/java/net/automatalib/util/ts/acceptor/AcceptanceCombiner.java
+++ b/util/src/main/java/net/automatalib/util/ts/acceptor/AcceptanceCombiner.java
@@ -15,6 +15,7 @@
  */
 package net.automatalib.util.ts.acceptor;
 
+@FunctionalInterface
 public interface AcceptanceCombiner {
 
     AcceptanceCombiner AND = (a1, a2) -> a1 && a2;

--- a/util/src/main/java/net/automatalib/util/ts/traversal/TSTraversal.java
+++ b/util/src/main/java/net/automatalib/util/ts/traversal/TSTraversal.java
@@ -426,20 +426,15 @@ public final class TSTraversal {
      *
      * @return {@code false} if the number of explored states reached {@code limit}, {@code true} otherwise
      */
-    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public static <S, I, T, D> boolean traverse(TraversalOrder order,
                                                 TransitionSystem<S, ? super I, T> ts,
                                                 int limit,
                                                 Collection<? extends I> inputs,
                                                 TSTraversalVisitor<S, I, T, D> visitor) {
-        switch (order) {
-            case BREADTH_FIRST:
-                return breadthFirst(ts, limit, inputs, visitor);
-            case DEPTH_FIRST:
-                return depthFirst(ts, limit, inputs, visitor);
-            default:
-                throw new IllegalArgumentException("Unknown traversal order: " + order);
-        }
+        return switch (order) {
+            case BREADTH_FIRST -> breadthFirst(ts, limit, inputs, visitor);
+            case DEPTH_FIRST -> depthFirst(ts, limit, inputs, visitor);
+        };
     }
 
 }

--- a/util/src/main/java/net/automatalib/util/ts/traversal/TSTraversal.java
+++ b/util/src/main/java/net/automatalib/util/ts/traversal/TSTraversal.java
@@ -111,9 +111,6 @@ public final class TSTraversal {
                         bfsQueue.offer(new BFSRecord<>(initS, dataHolder.value));
                         stateCount++;
                     }
-                    break;
-                default:
-                    throw new IllegalStateException("Unknown action " + act);
             }
         }
 
@@ -154,9 +151,6 @@ public final class TSTraversal {
                                 bfsQueue.offer(new BFSRecord<>(succ, dataHolder.value));
                                 stateCount++;
                             }
-                            break;
-                        default:
-                            throw new IllegalStateException("Unknown action " + act);
                     }
                 }
             }
@@ -280,9 +274,6 @@ public final class TSTraversal {
                         dfsStack.push(new DFRecord<>(initS, inputs, dataHolder.value));
                         stateCount++;
                     }
-                    break;
-                default:
-                    throw new IllegalStateException("Unknown action " + act);
             }
         }
 
@@ -342,9 +333,6 @@ public final class TSTraversal {
                         dfsStack.push(new DFRecord<>(succ, inputs, data));
                         stateCount++;
                     }
-                    break;
-                default:
-                    throw new IllegalStateException("Unknown action " + act);
             }
         }
 
@@ -438,6 +426,7 @@ public final class TSTraversal {
      *
      * @return {@code false} if the number of explored states reached {@code limit}, {@code true} otherwise
      */
+    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     public static <S, I, T, D> boolean traverse(TraversalOrder order,
                                                 TransitionSystem<S, ? super I, T> ts,
                                                 int limit,

--- a/util/src/main/java/net/automatalib/util/ts/traversal/TSTraversalMethod.java
+++ b/util/src/main/java/net/automatalib/util/ts/traversal/TSTraversalMethod.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 
 import net.automatalib.ts.TransitionSystem;
 
+@FunctionalInterface
 public interface TSTraversalMethod {
 
     TSTraversalMethod BREADTH_FIRST = TSTraversal::breadthFirst;

--- a/util/src/test/java/net/automatalib/util/automaton/equivalence/DeterministicEquivalenceTestTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/equivalence/DeterministicEquivalenceTestTest.java
@@ -178,10 +178,11 @@ public class DeterministicEquivalenceTestTest {
                                                                                                                       M a2,
                                                                                                                       Alphabet<I> alphabet,
                                                                                                                       boolean equivalent) {
-        final UniversalDeterministicAutomaton<?, I, ?, ?, ?> m1 = a1;
-        final UniversalDeterministicAutomaton<?, I, ?, ?, ?> m2 = a2;
 
-        final Word<I> separatingWord = DeterministicEquivalenceTest.findSeparatingWord(m1, m2, alphabet);
+        final Word<I> separatingWord =
+                DeterministicEquivalenceTest.findSeparatingWord((UniversalDeterministicAutomaton<?, I, ?, ?, ?>) a1,
+                                                                (UniversalDeterministicAutomaton<?, I, ?, ?, ?>) a2,
+                                                                alphabet);
 
         Assert.assertEquals(equivalent, separatingWord == null);
 

--- a/util/src/test/java/net/automatalib/util/automaton/equivalence/DeterministicEquivalenceTestTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/equivalence/DeterministicEquivalenceTestTest.java
@@ -136,7 +136,7 @@ public class DeterministicEquivalenceTestTest {
         testIndexComputation((int size1, int size2) -> new MapRegistry<>(size1));
     }
 
-    private static <I> void testIndexComputation(BiIntFunction<Registry<Integer>> constructor) {
+    private static void testIndexComputation(BiIntFunction<Registry<Integer>> constructor) {
         final int size1 = 3;
         final int size2 = 5;
         final Registry<Integer> registry = constructor.apply(size1, size2);
@@ -178,11 +178,11 @@ public class DeterministicEquivalenceTestTest {
                                                                                                                       M a2,
                                                                                                                       Alphabet<I> alphabet,
                                                                                                                       boolean equivalent) {
+        // explicitly assign type to (redundant) variables, otherwise javac complains
+        final UniversalDeterministicAutomaton<?, I, ?, ?, ?> m1 = a1;
+        final UniversalDeterministicAutomaton<?, I, ?, ?, ?> m2 = a2;
 
-        final Word<I> separatingWord =
-                DeterministicEquivalenceTest.findSeparatingWord((UniversalDeterministicAutomaton<?, I, ?, ?, ?>) a1,
-                                                                (UniversalDeterministicAutomaton<?, I, ?, ?, ?>) a2,
-                                                                alphabet);
+        final Word<I> separatingWord = DeterministicEquivalenceTest.findSeparatingWord(m1, m2, alphabet);
 
         Assert.assertEquals(equivalent, separatingWord == null);
 

--- a/util/src/test/java/net/automatalib/util/graph/TraversalTest.java
+++ b/util/src/test/java/net/automatalib/util/graph/TraversalTest.java
@@ -122,7 +122,7 @@ public class TraversalTest {
             for (TransitionEdge<Integer, Integer> e : path) {
                 Assert.assertTrue(nodeIter.hasNext());
 
-                final Integer i = e.getInput();
+                final Integer i = e.input();
                 sIter = automaton.getSuccessor(sIter, i);
                 nIter = nodeIter.next();
 
@@ -230,7 +230,7 @@ public class TraversalTest {
 
     private <S, I, T> List<Word<I>> collectPathInputs(Iterable<Path<S, TransitionEdge<I, T>>> paths) {
         return IterableUtil.stream(paths)
-                           .map(p -> p.stream().map(TransitionEdge::getInput).collect(Word.collector()))
+                           .map(p -> p.stream().map(TransitionEdge::input).collect(Word.collector()))
                            .collect(Collectors.toList());
     }
 

--- a/visualization/dot-visualizer/pom.xml
+++ b/visualization/dot-visualizer/pom.xml
@@ -117,7 +117,23 @@ limitations under the License.
                         <configuration>
                             <!-- core is only a testing dependency not defined in module-info.java -->
                             <!-- append to existing argLine to nicely work together with jacoco plugin -->
-                            <argLine>@{argLine} --add-reads=net.automatalib.visualization.dot=net.automatalib.core</argLine>
+                            <argLine>
+                                @{argLine}
+                                --add-reads=net.automatalib.visualization.dot=net.automatalib.core
+                                --add-exports=java.desktop/java.awt=ALL-UNNAMED
+                                --add-exports=java.desktop/java.awt.peer=ALL-UNNAMED
+                                --add-exports=java.desktop/sun.awt.image=ALL-UNNAMED
+                                --add-exports=java.desktop/sun.java2d=ALL-UNNAMED
+                                --add-exports=java.desktop/java.awt.dnd.peer=ALL-UNNAMED
+                                --add-exports=java.desktop/sun.awt=ALL-UNNAMED
+                                --add-exports=java.desktop/sun.awt.event=ALL-UNNAMED
+                                --add-exports=java.desktop/sun.awt.datatransfer=ALL-UNNAMED
+                                --add-exports=java.base/sun.security.action=ALL-UNNAMED
+                                --add-opens=java.base/java.util=ALL-UNNAMED
+                                --add-opens=java.desktop/java.awt=ALL-UNNAMED
+                                --add-opens=java.desktop/sun.java2d=ALL-UNNAMED
+                                --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+                            </argLine>
                         </configuration>
                     </execution>
                 </executions>

--- a/visualization/dot-visualizer/pom.xml
+++ b/visualization/dot-visualizer/pom.xml
@@ -102,15 +102,6 @@ limitations under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <!-- For some reason (probably due to the testing dependencies) surefire auto-detects a JUnit runner.
-                     Since we use testng exclusively, help the plugin a little bit -->
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-testng</artifactId>
-                        <version>${surefire-plugin.version}</version>
-                    </dependency>
-                </dependencies>
                 <executions>
                     <execution>
                         <id>default-test</id>

--- a/visualization/dot-visualizer/src/main/java/net/automatalib/visualization/dot/DOTMultiDialog.java
+++ b/visualization/dot-visualizer/src/main/java/net/automatalib/visualization/dot/DOTMultiDialog.java
@@ -120,6 +120,7 @@ final class DOTMultiDialog<I> extends JDialog {
         setVisible(true);
     }
 
+    @FunctionalInterface
     interface ThrowableExtractor<I, O> {
 
         O extract(I input) throws IOException;

--- a/visualization/dot-visualizer/src/test/java/net/automatalib/visualization/dot/ActivationListener.java
+++ b/visualization/dot-visualizer/src/test/java/net/automatalib/visualization/dot/ActivationListener.java
@@ -15,21 +15,23 @@
  */
 package net.automatalib.visualization.dot;
 
-import org.assertj.swing.testng.testcase.AssertJSwingTestngTestCase;
+import com.github.caciocavallosilano.cacio.ctc.junit.CacioExtension;
 import org.testng.IInvokedMethod;
 import org.testng.IInvokedMethodListener;
 import org.testng.ITestResult;
 import org.testng.SkipException;
 
 /**
- * This listener fully skips GUI tests including the (otherwise un-skipable)
- * {@link AssertJSwingTestngTestCase#setUpOnce} method.
+ * This listener checks wether GUI tests can be executed and if so, sets up the necessary headless environments.
  */
-public class DOTDialogListener implements IInvokedMethodListener {
+public class ActivationListener implements IInvokedMethodListener {
 
     @Override
     public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
-        if (!(DOT.checkUsable() && Runtime.version().feature() == 11)) {
+        if (TestUtil.shouldRunGUITests()) {
+            // hack: the static initializer of this class does the magic we want, so only invoke it on compatible JVMs
+            new CacioExtension();
+        } else {
             testResult.setThrowable(new SkipException(
                     "Either DOT is not available or the headless AWT environment is not supported"));
             testResult.setStatus(ITestResult.SKIP);

--- a/visualization/dot-visualizer/src/test/java/net/automatalib/visualization/dot/DOTDialogTest.java
+++ b/visualization/dot-visualizer/src/test/java/net/automatalib/visualization/dot/DOTDialogTest.java
@@ -39,7 +39,7 @@ import org.testng.Assert;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
-@Listeners(DOTDialogListener.class)
+@Listeners(ActivationListener.class)
 public class DOTDialogTest extends AssertJSwingTestngTestCase {
 
     private final String dot;

--- a/visualization/dot-visualizer/src/test/java/net/automatalib/visualization/dot/DOTMultiDialogTest.java
+++ b/visualization/dot-visualizer/src/test/java/net/automatalib/visualization/dot/DOTMultiDialogTest.java
@@ -25,28 +25,15 @@ import java.util.Random;
 import javax.swing.SwingUtilities;
 
 import net.automatalib.common.util.Pair;
-import org.testng.SkipException;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
+@Listeners(ActivationListener.class)
 public class DOTMultiDialogTest {
-
-    @BeforeClass
-    public void checkDOT() {
-        if (!DOT.checkUsable()) {
-            // Do not fail on platforms, where DOT is not installed
-            throw new SkipException("DOT is not installed");
-        }
-    }
 
     // Headless GUI testing is a pain. Therefore, just check that we don't throw any exceptions for now.
     @Test(timeOut = 30000)
     public void testFrame() throws InvocationTargetException, InterruptedException {
-
-        if (!(Runtime.version().feature() == 11)) {
-            throw new SkipException("The headless AWT environment currently only works with Java 11 or <=8");
-        }
-
         final Random r = new Random(42);
         final List<Pair<String, String>> graphs =
                 Arrays.asList(Pair.of("Automaton 1", TestUtil.generateRandomAutomatonDot(r)),
@@ -66,11 +53,6 @@ public class DOTMultiDialogTest {
     // Headless GUI testing is a pain. Therefore, just check that we don't throw any exceptions for now.
     @Test(timeOut = 30000)
     public void testEmptyFrame() throws InvocationTargetException, InterruptedException {
-
-        if (!(Runtime.version().feature() == 11)) {
-            throw new SkipException("The headless AWT environment currently only works with Java 11 or <=8");
-        }
-
         // invokeAndWait so that TestNG doesn't kill our GUI thread that we want to check.
         SwingUtilities.invokeAndWait(() -> {
             try {

--- a/visualization/dot-visualizer/src/test/java/net/automatalib/visualization/dot/FileVisualizationTest.java
+++ b/visualization/dot-visualizer/src/test/java/net/automatalib/visualization/dot/FileVisualizationTest.java
@@ -25,22 +25,14 @@ import net.automatalib.common.util.IOUtil;
 import net.automatalib.serialization.dot.GraphDOT;
 import net.automatalib.visualization.VisualizationHelper;
 import org.testng.Assert;
-import org.testng.SkipException;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 /**
  * A small test for checking, if writing directly to files is working.
  */
+@Listeners(ActivationListener.class)
 public class FileVisualizationTest {
-
-    @BeforeClass
-    public void checkDOT() {
-        if (!DOT.checkUsable()) {
-            // Do not fail on platforms, where DOT is not installed
-            throw new SkipException("DOT is not installed");
-        }
-    }
 
     @Test
     public void testFileVisualization() throws IOException, InterruptedException {

--- a/visualization/dot-visualizer/src/test/java/net/automatalib/visualization/dot/ProviderTest.java
+++ b/visualization/dot-visualizer/src/test/java/net/automatalib/visualization/dot/ProviderTest.java
@@ -57,8 +57,8 @@ public class ProviderTest {
     @Test(dependsOnMethods = "testProviderConfiguration", timeOut = 10000)
     public void testDisplay() throws InterruptedException, InvocationTargetException {
 
-        if (!(Runtime.version().feature() == 11)) {
-            throw new SkipException("The headless AWT environment currently only works with Java 11 or <=8");
+        if (!(TestUtil.shouldRunGUITests())) {
+            throw new SkipException("The conditions for running GUI tests are not met");
         }
 
         final CompactDFA<Integer> dfa = TestUtil.generateRandomAutomaton(new Random(42));

--- a/visualization/dot-visualizer/src/test/java/net/automatalib/visualization/dot/TestUtil.java
+++ b/visualization/dot-visualizer/src/test/java/net/automatalib/visualization/dot/TestUtil.java
@@ -51,4 +51,9 @@ public final class TestUtil {
 
         return writer.toString();
     }
+
+    static boolean shouldRunGUITests() {
+        final int feature = Runtime.version().feature();
+        return DOT.checkUsable() && (feature == 17 || feature == 21);
+    }
 }

--- a/visualization/jung-visualizer/pom.xml
+++ b/visualization/jung-visualizer/pom.xml
@@ -143,15 +143,6 @@ limitations under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <!-- For some reason (probably due to the testing dependencies) surefire auto-detects a JUnit runner.
-                     Since we use testng exclusively, help the plugin a little bit -->
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-testng</artifactId>
-                        <version>${surefire-plugin.version}</version>
-                    </dependency>
-                </dependencies>
                 <executions>
                     <execution>
                         <id>default-test</id>

--- a/visualization/jung-visualizer/pom.xml
+++ b/visualization/jung-visualizer/pom.xml
@@ -147,7 +147,7 @@ limitations under the License.
                     <execution>
                         <id>default-test</id>
                         <configuration>
-                            <!-- core is only a testing dependency not defined in module-info.java -->
+                            <!-- patch module to deal with the split packages of JUNG -->
                             <!-- append to existing argLine to nicely work together with jacoco plugin -->
                             <argLine>
                                 @{argLine}

--- a/visualization/jung-visualizer/pom.xml
+++ b/visualization/jung-visualizer/pom.xml
@@ -143,13 +143,38 @@ limitations under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <!-- For some reason (probably due to the testing dependencies) surefire auto-detects a JUnit runner.
+                     Since we use testng exclusively, help the plugin a little bit -->
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${surefire-plugin.version}</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>default-test</id>
                         <configuration>
                             <!-- core is only a testing dependency not defined in module-info.java -->
                             <!-- append to existing argLine to nicely work together with jacoco plugin -->
-                            <argLine>@{argLine} --patch-module=jung.api=${net.sf.jung:jung-graph-impl:jar}</argLine>
+                            <argLine>
+                                @{argLine}
+                                --patch-module=jung.api=${net.sf.jung:jung-graph-impl:jar}
+                                --add-exports=java.desktop/java.awt=ALL-UNNAMED
+                                --add-exports=java.desktop/java.awt.peer=ALL-UNNAMED
+                                --add-exports=java.desktop/sun.awt.image=ALL-UNNAMED
+                                --add-exports=java.desktop/sun.java2d=ALL-UNNAMED
+                                --add-exports=java.desktop/java.awt.dnd.peer=ALL-UNNAMED
+                                --add-exports=java.desktop/sun.awt=ALL-UNNAMED
+                                --add-exports=java.desktop/sun.awt.event=ALL-UNNAMED
+                                --add-exports=java.desktop/sun.awt.datatransfer=ALL-UNNAMED
+                                --add-exports=java.base/sun.security.action=ALL-UNNAMED
+                                --add-opens=java.base/java.util=ALL-UNNAMED
+                                --add-opens=java.desktop/java.awt=ALL-UNNAMED
+                                --add-opens=java.desktop/sun.java2d=ALL-UNNAMED
+                                --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+                            </argLine>
                         </configuration>
                     </execution>
                 </executions>

--- a/visualization/jung-visualizer/src/test/java/net/automatalib/visualization/jung/ProviderTest.java
+++ b/visualization/jung-visualizer/src/test/java/net/automatalib/visualization/jung/ProviderTest.java
@@ -63,7 +63,7 @@ public class ProviderTest {
 
     private static void checkExecution() {
         final int feature = Runtime.version().feature();
-        if (feature == 17) { // TODO: Java 21 currently crashes when loading fonts. Bug in the JVM?
+        if (feature == 17 || feature == 21) {
             // hack: the static initializer of this class does the magic we want, so only invoke it on compatible JVMs
             new CacioExtension();
         } else {

--- a/visualization/jung-visualizer/src/test/java/net/automatalib/visualization/jung/ProviderTest.java
+++ b/visualization/jung-visualizer/src/test/java/net/automatalib/visualization/jung/ProviderTest.java
@@ -63,7 +63,8 @@ public class ProviderTest {
 
     private static void checkExecution() {
         final int feature = Runtime.version().feature();
-        if (feature == 17) { // TODO: Java 21 currently crashes when loading fonts. Bug in the JVM?
+        // TODO: Java 21 currently crashes when loading fonts. See https://github.com/CaciocavalloSilano/caciocavallo/issues/18
+        if (feature == 17) {
             // hack: the static initializer of this class does the magic we want, so only invoke it on compatible JVMs
             new CacioExtension();
         } else {

--- a/visualization/jung-visualizer/src/test/java/net/automatalib/visualization/jung/ProviderTest.java
+++ b/visualization/jung-visualizer/src/test/java/net/automatalib/visualization/jung/ProviderTest.java
@@ -31,19 +31,9 @@ import net.automatalib.visualization.VisualizationHelper;
 import net.automatalib.visualization.VisualizationProvider;
 import org.testng.Assert;
 import org.testng.SkipException;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class ProviderTest {
-
-    @BeforeClass
-    public void setupCacio() throws InterruptedException, InvocationTargetException {
-        if (shouldRunGUITests()) {
-            // hack: the static initializer of this class does the magic we want, so only invoke it on compatible JVMs
-            // hack2: run on the EDT so that we get invoked before JUNG triggers conflicting AWT initializations
-            SwingUtilities.invokeAndWait(CacioExtension::new);
-        }
-    }
 
     @Test
     public void testProviderConfiguration() {
@@ -60,9 +50,7 @@ public class ProviderTest {
     @Test(dependsOnMethods = "testProviderConfiguration", timeOut = 30000)
     public void testDisplay() throws InterruptedException, InvocationTargetException {
 
-        if (!shouldRunGUITests()) {
-            throw new SkipException("The headless AWT environment is not supported on this platform");
-        }
+        checkExecution();
 
         final Random random = new Random(42);
         final CompactDFA<Integer> dfa = RandomAutomata.randomDFA(random, 10, Alphabets.integers(1, 6));
@@ -73,9 +61,14 @@ public class ProviderTest {
                                                                    new RandomEdgeStyler<>(random)));
     }
 
-    private static boolean shouldRunGUITests() {
+    private static void checkExecution() {
         final int feature = Runtime.version().feature();
-        return feature == 17 || feature == 21;
+        if (feature == 17 || feature == 21) {
+            // hack: the static initializer of this class does the magic we want, so only invoke it on compatible JVMs
+            new CacioExtension();
+        } else {
+            throw new SkipException("The headless AWT environment is not supported on this platform");
+        }
     }
 
     private static final class RandomEdgeStyler<N, E> implements VisualizationHelper<N, E> {

--- a/visualization/jung-visualizer/src/test/java/net/automatalib/visualization/jung/ProviderTest.java
+++ b/visualization/jung-visualizer/src/test/java/net/automatalib/visualization/jung/ProviderTest.java
@@ -21,6 +21,7 @@ import java.util.Random;
 
 import javax.swing.SwingUtilities;
 
+import com.github.caciocavallosilano.cacio.ctc.junit.CacioExtension;
 import net.automatalib.alphabet.impl.Alphabets;
 import net.automatalib.automaton.fsa.impl.CompactDFA;
 import net.automatalib.util.automaton.random.RandomAutomata;
@@ -49,9 +50,7 @@ public class ProviderTest {
     @Test(dependsOnMethods = "testProviderConfiguration", timeOut = 30000)
     public void testDisplay() throws InterruptedException, InvocationTargetException {
 
-        if (!(Runtime.version().feature() == 11)) {
-            throw new SkipException("The headless AWT environment currently only works with Java 11 or <=8");
-        }
+        checkExecution();
 
         final Random random = new Random(42);
         final CompactDFA<Integer> dfa = RandomAutomata.randomDFA(random, 10, Alphabets.integers(1, 6));
@@ -60,6 +59,16 @@ public class ProviderTest {
         SwingUtilities.invokeAndWait(() -> Visualization.visualize(dfa.graphView(),
                                                                    false,
                                                                    new RandomEdgeStyler<>(random)));
+    }
+
+    private static void checkExecution() {
+        final int feature = Runtime.version().feature();
+        if (feature == 17 || feature == 21) {
+            // hack: the static initializer of this class does the magic we want, so only invoke it on compatible JVMs
+            new CacioExtension();
+        } else {
+            throw new SkipException("The headless AWT environment is not supported on this platform");
+        }
     }
 
     private static final class RandomEdgeStyler<N, E> implements VisualizationHelper<N, E> {

--- a/visualization/jung-visualizer/src/test/java/net/automatalib/visualization/jung/ProviderTest.java
+++ b/visualization/jung-visualizer/src/test/java/net/automatalib/visualization/jung/ProviderTest.java
@@ -63,7 +63,7 @@ public class ProviderTest {
 
     private static void checkExecution() {
         final int feature = Runtime.version().feature();
-        if (feature == 17 || feature == 21) {
+        if (feature == 17) { // TODO: Java 21 currently crashes when loading fonts. Bug in the JVM?
             // hack: the static initializer of this class does the magic we want, so only invoke it on compatible JVMs
             new CacioExtension();
         } else {

--- a/visualization/jung-visualizer/src/test/java/net/automatalib/visualization/jung/ProviderTest.java
+++ b/visualization/jung-visualizer/src/test/java/net/automatalib/visualization/jung/ProviderTest.java
@@ -31,9 +31,19 @@ import net.automatalib.visualization.VisualizationHelper;
 import net.automatalib.visualization.VisualizationProvider;
 import org.testng.Assert;
 import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class ProviderTest {
+
+    @BeforeClass
+    public void setupCacio() throws InterruptedException, InvocationTargetException {
+        if (shouldRunGUITests()) {
+            // hack: the static initializer of this class does the magic we want, so only invoke it on compatible JVMs
+            // hack2: run on the EDT so that we get invoked before JUNG triggers conflicting AWT initializations
+            SwingUtilities.invokeAndWait(CacioExtension::new);
+        }
+    }
 
     @Test
     public void testProviderConfiguration() {
@@ -50,7 +60,9 @@ public class ProviderTest {
     @Test(dependsOnMethods = "testProviderConfiguration", timeOut = 30000)
     public void testDisplay() throws InterruptedException, InvocationTargetException {
 
-        checkExecution();
+        if (!shouldRunGUITests()) {
+            throw new SkipException("The headless AWT environment is not supported on this platform");
+        }
 
         final Random random = new Random(42);
         final CompactDFA<Integer> dfa = RandomAutomata.randomDFA(random, 10, Alphabets.integers(1, 6));
@@ -61,14 +73,9 @@ public class ProviderTest {
                                                                    new RandomEdgeStyler<>(random)));
     }
 
-    private static void checkExecution() {
+    private static boolean shouldRunGUITests() {
         final int feature = Runtime.version().feature();
-        if (feature == 17 || feature == 21) {
-            // hack: the static initializer of this class does the magic we want, so only invoke it on compatible JVMs
-            new CacioExtension();
-        } else {
-            throw new SkipException("The headless AWT environment is not supported on this platform");
-        }
+        return feature == 17 || feature == 21;
     }
 
     private static final class RandomEdgeStyler<N, E> implements VisualizationHelper<N, E> {

--- a/visualization/pom.xml
+++ b/visualization/pom.xml
@@ -42,11 +42,21 @@ limitations under the License.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <systemPropertyVariables>
-                        <awt.toolkit>com.github.caciocavallosilano.cacio.ctc.CTCToolkit</awt.toolkit>
-                        <java.awt.graphicsenv>com.github.caciocavallosilano.cacio.ctc.CTCGraphicsEnvironment</java.awt.graphicsenv>
-                        <java.awt.headless>false</java.awt.headless>
-                    </systemPropertyVariables>
+                    <argLine>
+                        --add-exports=java.desktop/java.awt=ALL-UNNAMED
+                        --add-exports=java.desktop/java.awt.peer=ALL-UNNAMED
+                        --add-exports=java.desktop/sun.awt.image=ALL-UNNAMED
+                        --add-exports=java.desktop/sun.java2d=ALL-UNNAMED
+                        --add-exports=java.desktop/java.awt.dnd.peer=ALL-UNNAMED
+                        --add-exports=java.desktop/sun.awt=ALL-UNNAMED
+                        --add-exports=java.desktop/sun.awt.event=ALL-UNNAMED
+                        --add-exports=java.desktop/sun.awt.datatransfer=ALL-UNNAMED
+                        --add-exports=java.base/sun.security.action=ALL-UNNAMED
+                        --add-opens=java.base/java.util=ALL-UNNAMED
+                        --add-opens=java.desktop/java.awt=ALL-UNNAMED
+                        --add-opens=java.desktop/sun.java2d=ALL-UNNAMED
+                        --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+                    </argLine>
                 </configuration>
                 <executions>
                     <!-- since we use META-INF/services, also test in classpath mode -->

--- a/visualization/pom.xml
+++ b/visualization/pom.xml
@@ -55,6 +55,7 @@ limitations under the License.
                         <java.awt.headless>false</java.awt.headless>
                     </systemPropertyVariables>
                     <argLine>
+                        @{argLine}
                         --add-exports=java.desktop/java.awt=ALL-UNNAMED
                         --add-exports=java.desktop/java.awt.peer=ALL-UNNAMED
                         --add-exports=java.desktop/sun.awt.image=ALL-UNNAMED

--- a/visualization/pom.xml
+++ b/visualization/pom.xml
@@ -42,6 +42,9 @@ limitations under the License.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <systemPropertyVariables>
+                        <java.awt.headless>false</java.awt.headless>
+                    </systemPropertyVariables>
                     <argLine>
                         --add-exports=java.desktop/java.awt=ALL-UNNAMED
                         --add-exports=java.desktop/java.awt.peer=ALL-UNNAMED

--- a/visualization/pom.xml
+++ b/visualization/pom.xml
@@ -41,6 +41,15 @@ limitations under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <!-- For some reason (probably due to the testing dependencies) surefire auto-detects a JUnit runner.
+                     Since we use testng exclusively, help the plugin a little bit -->
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${surefire-plugin.version}</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
                     <systemPropertyVariables>
                         <java.awt.headless>false</java.awt.headless>


### PR DESCRIPTION
This PR raises the minimal Java version to 17 and includes certain cleanups that the new language features allow for.

Addtionally, it adds support for the new Java LTS version 25. As this requires a bump in our analysis plugins which include new/improved checks, this also contains the necessary refactorings to make the build process pass again.