### PR TITLE
Add (de-)serializers for (explicit) NFAs in the `.mata` format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 * A new formalism for *Mealy machines with local timers* (MMLTs) including means for conformance testing and equivalence checking has been added (thanks to [Paul Kogel](https://github.com/pdev55)).
+* Added a new `automata-serialization-mata` module for serializing (explicit) NFAs in the `.mata` format as used by the [mata library](https://github.com/VeriFIT/mata).
 * `automata-modelchecking-m3c` now supports ARM-based macOS systems.
 * `automata-modelchecking-m3c` can now be included in jlink images.
 

--- a/build-config/src/main/resources/automatalib-spotbugs-exclusions.xml
+++ b/build-config/src/main/resources/automatalib-spotbugs-exclusions.xml
@@ -86,6 +86,14 @@ limitations under the License.
             <Class name="net.automatalib.serialization.dot.Token"/>
             <Class name="net.automatalib.serialization.dot.TokenMgrError"/>
 
+            <Class name="net.automatalib.serialization.mata.parser.ExplicitMataParser"/>
+            <Class name="net.automatalib.serialization.mata.parser.ExplicitMataParserConstants"/>
+            <Class name="net.automatalib.serialization.mata.parser.ExplicitMataParserTokenManager"/>
+            <Class name="net.automatalib.serialization.mata.parser.ParseException"/>
+            <Class name="net.automatalib.serialization.mata.parser.SimpleCharStream"/>
+            <Class name="net.automatalib.serialization.mata.parser.Token"/>
+            <Class name="net.automatalib.serialization.mata.parser.TokenMgrError"/>
+
             <Class name="net.automatalib.serialization.taf.parser.InternalTAFParser"/>
             <Class name="net.automatalib.serialization.taf.parser.InternalTAFParserConstants"/>
             <Class name="net.automatalib.serialization.taf.parser.InternalTAFParserTokenManager"/>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -67,6 +67,13 @@ limitations under the License.
                             <exclude>net/automatalib/serialization/dot/Token.class</exclude>
                             <exclude>net/automatalib/serialization/dot/TokenMgrError.class</exclude>
 
+                            <!-- generated parser for Mata serialization -->
+                            <exclude>net/automatalib/serialization/mata/ExplicitMataParser*.class</exclude>
+                            <exclude>net/automatalib/serialization/mata/ParseException.class</exclude>
+                            <exclude>net/automatalib/serialization/mata/SimpleCharStream.class</exclude>
+                            <exclude>net/automatalib/serialization/mata/Token.class</exclude>
+                            <exclude>net/automatalib/serialization/mata/TokenMgrError.class</exclude>
+
                             <!-- generated parser for TAF serialization -->
                             <exclude>net/automatalib/serialization/taf/parser/InternalTAFParser*.class</exclude>
                             <exclude>net/automatalib/serialization/taf/parser/ParseException.class</exclude>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -68,11 +68,11 @@ limitations under the License.
                             <exclude>net/automatalib/serialization/dot/TokenMgrError.class</exclude>
 
                             <!-- generated parser for Mata serialization -->
-                            <exclude>net/automatalib/serialization/mata/ExplicitMataParser*.class</exclude>
-                            <exclude>net/automatalib/serialization/mata/ParseException.class</exclude>
-                            <exclude>net/automatalib/serialization/mata/SimpleCharStream.class</exclude>
-                            <exclude>net/automatalib/serialization/mata/Token.class</exclude>
-                            <exclude>net/automatalib/serialization/mata/TokenMgrError.class</exclude>
+                            <exclude>net/automatalib/serialization/mata/parser/ExplicitMataParser*.class</exclude>
+                            <exclude>net/automatalib/serialization/mata/parser/ParseException.class</exclude>
+                            <exclude>net/automatalib/serialization/mata/parser/SimpleCharStream.class</exclude>
+                            <exclude>net/automatalib/serialization/mata/parser/Token.class</exclude>
+                            <exclude>net/automatalib/serialization/mata/parser/TokenMgrError.class</exclude>
 
                             <!-- generated parser for TAF serialization -->
                             <exclude>net/automatalib/serialization/taf/parser/InternalTAFParser*.class</exclude>
@@ -267,6 +267,7 @@ limitations under the License.
                                         <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
                                         <arg>-AskipDefs=^net.automatalib.serialization.taf.parser.(Internal.*|Token.*|SimpleCharStream)|\
                                                         ^net.automatalib.serialization.dot.(Internal.*|Token.*|SimpleCharStream)|\
+                                                        ^net.automatalib.serialization.mata.parser.(Explicit.*|Token.*|SimpleCharStream)|\
                                                         ^net.automatalib.modelchecker.ltsmin.(Internal.*|Token.*|SimpleCharStream)|\
                                                         ^net.automatalib.modelchecker.m3c.formula.parser.(Internal.*|Token.*|SimpleCharStream)|\
                                         </arg>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -130,6 +130,11 @@ limitations under the License.
 
         <dependency>
             <groupId>net.automatalib</groupId>
+            <artifactId>automata-serialization-mata</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>net.automatalib</groupId>
             <artifactId>automata-serialization-saf</artifactId>
         </dependency>
 
@@ -325,6 +330,13 @@ limitations under the License.
                 <dependency>
                     <groupId>net.automatalib</groupId>
                     <artifactId>automata-serialization-learnlibv2</artifactId>
+                    <version>${project.version}</version>
+                    <classifier>sources</classifier>
+                </dependency>
+
+                <dependency>
+                    <groupId>net.automatalib</groupId>
+                    <artifactId>automata-serialization-mata</artifactId>
                     <version>${project.version}</version>
                     <classifier>sources</classifier>
                 </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -430,6 +430,11 @@ limitations under the License.
             </dependency>
             <dependency>
                 <groupId>net.automatalib</groupId>
+                <artifactId>automata-serialization-mata</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.automatalib</groupId>
                 <artifactId>automata-serialization-saf</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/serialization/mata/pom.xml
+++ b/serialization/mata/pom.xml
@@ -29,7 +29,7 @@ limitations under the License.
     <packaging>jar</packaging>
 
     <name>AutomataLib :: Serialization :: Mata</name>
-    <description>(De-)Serializers for the Mata Automaton Format</description>
+    <description>(De-)Serializers for the Mata automaton format</description>
 
     <dependencies>
         <!-- internal -->
@@ -44,12 +44,6 @@ limitations under the License.
         <dependency>
             <groupId>net.automatalib</groupId>
             <artifactId>automata-core</artifactId>
-        </dependency>
-
-        <!-- external -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
         </dependency>
 
         <!-- build -->

--- a/serialization/mata/pom.xml
+++ b/serialization/mata/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+Copyright (C) 2013-2025 TU Dortmund University
+This file is part of AutomataLib <https://automatalib.net>.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.automatalib</groupId>
+        <artifactId>automata-serialization-parent</artifactId>
+        <version>0.13.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>automata-serialization-mata</artifactId>
+    <packaging>jar</packaging>
+
+    <name>AutomataLib :: Serialization :: Mata</name>
+    <description>(De-)Serializers for the Mata Automaton Format</description>
+
+    <dependencies>
+        <!-- internal -->
+        <dependency>
+            <groupId>net.automatalib</groupId>
+            <artifactId>automata-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.automatalib</groupId>
+            <artifactId>automata-commons-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.automatalib</groupId>
+            <artifactId>automata-core</artifactId>
+        </dependency>
+
+        <!-- external -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- build -->
+        <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+        </dependency>
+
+        <!-- test -->
+        <dependency>
+            <groupId>net.automatalib</groupId>
+            <artifactId>automata-util</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>javacc-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/serialization/mata/src/main/java/module-info.java
+++ b/serialization/mata/src/main/java/module-info.java
@@ -15,7 +15,7 @@
  */
 
 /**
- * This module contains (de-) serializers for the Mata Automaton Format. Mata is a format used by the <a
+ * This module contains (de-) serializers for the Mata automaton format. This format is used by the <a
  * href="https://doi.org/10.1007/978-3-031-57249-4_7">Mata Automata Library</a>.
  * <p>
  * This module is provided by the following Maven dependency:

--- a/serialization/mata/src/main/java/module-info.java
+++ b/serialization/mata/src/main/java/module-info.java
@@ -32,7 +32,6 @@ open module net.automatalib.serialization.mata {
     requires net.automatalib.api;
     requires net.automatalib.common.util;
     requires net.automatalib.core;
-    requires org.slf4j;
 
     // annotations are 'provided'-scoped and do not need to be loaded at runtime
     requires static org.checkerframework.checker.qual;

--- a/serialization/mata/src/main/java/module-info.java
+++ b/serialization/mata/src/main/java/module-info.java
@@ -1,0 +1,42 @@
+/* Copyright (C) 2013-2025 TU Dortmund University
+ * This file is part of AutomataLib <https://automatalib.net>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This module contains (de-) serializers for the Mata Automaton Format. Mata is a format used by the <a
+ * href="https://doi.org/10.1007/978-3-031-57249-4_7">Mata Automata Library</a>.
+ * <p>
+ * This module is provided by the following Maven dependency:
+ * <pre>
+ * &lt;dependency&gt;
+ *   &lt;groupId&gt;net.automatalib&lt;/groupId&gt;
+ *   &lt;artifactId&gt;automata-serialization-mata&lt;/artifactId&gt;
+ *   &lt;version&gt;${version}&lt;/version&gt;
+ * &lt;/dependency&gt;
+ * </pre>
+ */
+open module net.automatalib.serialization.mata {
+
+    requires net.automatalib.api;
+    requires net.automatalib.common.util;
+    requires net.automatalib.core;
+    requires org.slf4j;
+
+    // annotations are 'provided'-scoped and do not need to be loaded at runtime
+    requires static org.checkerframework.checker.qual;
+
+    exports net.automatalib.serialization.mata.parser;
+    exports net.automatalib.serialization.mata.writer;
+}

--- a/serialization/mata/src/main/java/net/automatalib/serialization/mata/parser/MataNFAParser.java
+++ b/serialization/mata/src/main/java/net/automatalib/serialization/mata/parser/MataNFAParser.java
@@ -22,16 +22,36 @@ import java.util.function.Function;
 
 import net.automatalib.automaton.AutomatonCreator;
 import net.automatalib.automaton.fsa.MutableNFA;
+import net.automatalib.automaton.fsa.NFA;
 import net.automatalib.common.util.IOUtil;
 import net.automatalib.exception.FormatException;
 import net.automatalib.serialization.InputModelData;
 import net.automatalib.serialization.InputModelDeserializer;
 
+/**
+ * Parser for reading {@link NFA}s from the <a
+ * href="https://github.com/VeriFIT/mata/blob/devel/AUTOMATAFORMAT.md">NFA-explicit</a> format.
+ *
+ * @param <S>
+ *         state type
+ * @param <I>
+ *         input symbol type
+ * @param <A>
+ *         concrete automaton type
+ */
 public class MataNFAParser<S, I, A extends MutableNFA<S, I>> implements InputModelDeserializer<I, A> {
 
     private final AutomatonCreator<A, I> creator;
     private final Function<String, I> symbolParser;
 
+    /**
+     * Constructor.
+     *
+     * @param creator
+     *         the creator of the concrete NFA instance
+     * @param symbolParser
+     *         the parser for transforming (string-based) labels to concrete input symbols
+     */
     public MataNFAParser(AutomatonCreator<A, I> creator, Function<String, I> symbolParser) {
         this.creator = creator;
         this.symbolParser = symbolParser;
@@ -39,17 +59,45 @@ public class MataNFAParser<S, I, A extends MutableNFA<S, I>> implements InputMod
 
     @Override
     public InputModelData<I, A> readModel(InputStream is) throws IOException, FormatException {
-
         try (Reader r = IOUtil.asNonClosingUTF8Reader(is)) {
-            final ExplicitMataParser parser = new ExplicitMataParser(r);
-
-            try {
-                parser.parse();
-            } catch (ParseException ex) {
-                throw new FormatException(ex);
-            }
-
-            return parser.extract(creator, symbolParser);
+            return parse(r, creator, symbolParser);
         }
+    }
+
+    /**
+     * Reads the contents from the given input stream and de-serializes it into a model instance.
+     *
+     * @param reader
+     *         the reader to read the contents from
+     * @param creator
+     *         the creator of the concrete NFA instance
+     * @param symbolParser
+     *         the parser for transforming (string-based) labels to concrete input symbols
+     * @param <S>
+     *         state type
+     * @param <I>
+     *         input symbol type
+     * @param <A>
+     *         concrete automaton type
+     *
+     * @return the de-serialized model data
+     *
+     * @throws FormatException
+     *         if the content of the stream was not in the expected format
+     */
+    public static <S, I, A extends MutableNFA<S, I>> InputModelData<I, A> parse(Reader reader,
+                                                                                AutomatonCreator<A, I> creator,
+                                                                                Function<String, I> symbolParser)
+            throws FormatException {
+
+        final ExplicitMataParser parser = new ExplicitMataParser(reader);
+
+        try {
+            parser.parse();
+        } catch (ParseException ex) {
+            throw new FormatException(ex);
+        }
+
+        return parser.extract(creator, symbolParser);
     }
 }

--- a/serialization/mata/src/main/java/net/automatalib/serialization/mata/parser/MataNFAParser.java
+++ b/serialization/mata/src/main/java/net/automatalib/serialization/mata/parser/MataNFAParser.java
@@ -1,0 +1,55 @@
+/* Copyright (C) 2013-2025 TU Dortmund University
+ * This file is part of AutomataLib <https://automatalib.net>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.automatalib.serialization.mata.parser;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.util.function.Function;
+
+import net.automatalib.automaton.AutomatonCreator;
+import net.automatalib.automaton.fsa.MutableNFA;
+import net.automatalib.common.util.IOUtil;
+import net.automatalib.exception.FormatException;
+import net.automatalib.serialization.InputModelData;
+import net.automatalib.serialization.InputModelDeserializer;
+
+public class MataNFAParser<S, I, A extends MutableNFA<S, I>> implements InputModelDeserializer<I, A> {
+
+    private final AutomatonCreator<A, I> creator;
+    private final Function<String, I> symbolParser;
+
+    public MataNFAParser(AutomatonCreator<A, I> creator, Function<String, I> symbolParser) {
+        this.creator = creator;
+        this.symbolParser = symbolParser;
+    }
+
+    @Override
+    public InputModelData<I, A> readModel(InputStream is) throws IOException, FormatException {
+
+        try (Reader r = IOUtil.asNonClosingUTF8Reader(is)) {
+            final ExplicitMataParser parser = new ExplicitMataParser(r);
+
+            try {
+                parser.parse();
+            } catch (ParseException ex) {
+                throw new FormatException(ex);
+            }
+
+            return parser.extract(creator, symbolParser);
+        }
+    }
+}

--- a/serialization/mata/src/main/java/net/automatalib/serialization/mata/writer/MataNFAWriter.java
+++ b/serialization/mata/src/main/java/net/automatalib/serialization/mata/writer/MataNFAWriter.java
@@ -63,13 +63,14 @@ public class MataNFAWriter<I> implements InputModelSerializer<I, NFA<?, I>> {
      */
     public static <S, I> void write(Writer w, NFA<S, I> model, Alphabet<I> alphabet) throws IOException {
 
-        w.write("@NFA-explicit\n");
+        w.write("@NFA-explicit");
+        w.write(System.lineSeparator());
         w.write("%Alphabet");
         for (int i = 0; i < alphabet.size(); i++) {
             w.write(' ');
             w.write(Integer.toString(i));
         }
-        w.write('\n');
+        w.write(System.lineSeparator());
 
         final StateIDs<S> stateIDs = model.stateIDs();
         final List<Integer> finals = new ArrayList<>(model.size());
@@ -84,7 +85,7 @@ public class MataNFAWriter<I> implements InputModelSerializer<I, NFA<?, I>> {
                 finals.add(id);
             }
         }
-        w.write('\n');
+        w.write(System.lineSeparator());
 
         w.write("%Initial");
         for (S init : model.getInitialStates()) {
@@ -92,7 +93,7 @@ public class MataNFAWriter<I> implements InputModelSerializer<I, NFA<?, I>> {
             w.write('q');
             w.write(Integer.toString(stateIDs.getStateId(init)));
         }
-        w.write('\n');
+        w.write(System.lineSeparator());
 
         w.write("%Final");
         for (Integer s : finals) {
@@ -100,7 +101,7 @@ public class MataNFAWriter<I> implements InputModelSerializer<I, NFA<?, I>> {
             w.write('q');
             w.write(Integer.toString(s));
         }
-        w.write('\n');
+        w.write(System.lineSeparator());
 
         for (S s : model) {
             for (int i = 0; i < alphabet.size(); i++) {
@@ -112,7 +113,7 @@ public class MataNFAWriter<I> implements InputModelSerializer<I, NFA<?, I>> {
                     w.write(' ');
                     w.write('q');
                     w.write(Integer.toString(stateIDs.getStateId(t)));
-                    w.write('\n');
+                    w.write(System.lineSeparator());
                 }
             }
         }

--- a/serialization/mata/src/main/java/net/automatalib/serialization/mata/writer/MataNFAWriter.java
+++ b/serialization/mata/src/main/java/net/automatalib/serialization/mata/writer/MataNFAWriter.java
@@ -1,0 +1,95 @@
+/* Copyright (C) 2013-2025 TU Dortmund University
+ * This file is part of AutomataLib <https://automatalib.net>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.automatalib.serialization.mata.writer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
+
+import net.automatalib.alphabet.Alphabet;
+import net.automatalib.automaton.concept.StateIDs;
+import net.automatalib.automaton.fsa.NFA;
+import net.automatalib.common.util.IOUtil;
+import net.automatalib.serialization.InputModelSerializer;
+
+public class MataNFAWriter<I> implements InputModelSerializer<I, NFA<?, I>> {
+
+    @Override
+    public void writeModel(OutputStream os, NFA<?, I> model, Alphabet<I> alphabet) throws IOException {
+        try (Writer w = IOUtil.asNonClosingUTF8Writer(os)) {
+            write(w, model, alphabet);
+        }
+    }
+
+    private <S> void write(Writer w, NFA<S, I> model, Alphabet<I> alphabet) throws IOException {
+
+        w.write("@NFA-explicit\n");
+        w.write("%Alphabet");
+        for (int i = 0; i < alphabet.size(); i++) {
+            w.write(' ');
+            w.write(Integer.toString(i));
+        }
+        w.write('\n');
+
+        final StateIDs<S> stateIDs = model.stateIDs();
+        final List<Integer> finals = new ArrayList<>(model.size());
+
+        w.write("%States");
+        for (S s : model) {
+            int id = stateIDs.getStateId(s);
+            w.write(' ');
+            w.write('q');
+            w.write(Integer.toString(id));
+            if (model.isAccepting(s)) {
+                finals.add(id);
+            }
+        }
+        w.write('\n');
+
+        w.write("%Initial");
+        for (S init : model.getInitialStates()) {
+            w.write(' ');
+            w.write('q');
+            w.write(Integer.toString(stateIDs.getStateId(init)));
+        }
+        w.write('\n');
+
+        w.write("%Final");
+        for (Integer s : finals) {
+            w.write(' ');
+            w.write('q');
+            w.write(Integer.toString(s));
+        }
+        w.write('\n');
+
+        for (S s : model) {
+            for (int i = 0; i < alphabet.size(); i++) {
+                for (S t : model.getSuccessors(s, alphabet.getSymbol(i))) {
+                    w.write('q');
+                    w.write(Integer.toString(stateIDs.getStateId(s)));
+                    w.write(' ');
+                    w.write(Integer.toString(i));
+                    w.write(' ');
+                    w.write('q');
+                    w.write(Integer.toString(stateIDs.getStateId(t)));
+                    w.write('\n');
+                }
+            }
+        }
+    }
+}

--- a/serialization/mata/src/main/java/net/automatalib/serialization/mata/writer/MataNFAWriter.java
+++ b/serialization/mata/src/main/java/net/automatalib/serialization/mata/writer/MataNFAWriter.java
@@ -27,6 +27,14 @@ import net.automatalib.automaton.fsa.NFA;
 import net.automatalib.common.util.IOUtil;
 import net.automatalib.serialization.InputModelSerializer;
 
+/**
+ * Writer for serializing {@link NFA}s into the <a
+ * href="https://github.com/VeriFIT/mata/blob/devel/AUTOMATAFORMAT.md">NFA-explicit</a> format. States and inputs are
+ * typically represented by their respective index.
+ *
+ * @param <I>
+ *         input symbol type
+ */
 public class MataNFAWriter<I> implements InputModelSerializer<I, NFA<?, I>> {
 
     @Override
@@ -36,7 +44,24 @@ public class MataNFAWriter<I> implements InputModelSerializer<I, NFA<?, I>> {
         }
     }
 
-    private <S> void write(Writer w, NFA<S, I> model, Alphabet<I> alphabet) throws IOException {
+    /**
+     * Writes the given NFA to the given writer.
+     *
+     * @param w
+     *         the writer to write to
+     * @param model
+     *         the model to write
+     * @param alphabet
+     *         the inputs of the model to which serialization should be limited
+     * @param <S>
+     *         state type
+     * @param <I>
+     *         input symbol type
+     *
+     * @throws IOException
+     *         when writing to the output stream fails.
+     */
+    public static <S, I> void write(Writer w, NFA<S, I> model, Alphabet<I> alphabet) throws IOException {
 
         w.write("@NFA-explicit\n");
         w.write("%Alphabet");

--- a/serialization/mata/src/main/javacc/mata-explicit.jj
+++ b/serialization/mata/src/main/javacc/mata-explicit.jj
@@ -1,0 +1,212 @@
+/* Copyright (C) 2013-2025 TU Dortmund University
+ * This file is part of AutomataLib <https://automatalib.net>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+options {
+	LOOKAHEAD = 1;
+	STATIC = false;
+	SUPPORT_CLASS_VISIBILITY_PUBLIC = false;
+}
+
+PARSER_BEGIN(ExplicitMataParser)
+
+package net.automatalib.serialization.mata.parser;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import net.automatalib.alphabet.Alphabet;
+import net.automatalib.alphabet.impl.Alphabets;
+import net.automatalib.automaton.AutomatonCreator;
+import net.automatalib.automaton.fsa.MutableNFA;
+import net.automatalib.automaton.fsa.NFA;
+import net.automatalib.automaton.fsa.impl.CompactNFA;
+import net.automatalib.automaton.fsa.impl.FastNFA;
+import net.automatalib.common.util.HashUtil;
+import net.automatalib.common.util.Triple;
+import net.automatalib.exception.FormatException;
+import net.automatalib.serialization.InputModelData;
+
+public class ExplicitMataParser {
+
+	private NFA<?, Integer> nfa;
+	private Alphabet<Integer> alphabet;
+
+	private Set<String> labels;
+	private Set<String> states;
+	private Set<String> initials;
+	private Set<String> finals;
+	private List<Triple<String, String, String>> transitions;
+	private boolean parsed;
+
+
+	public void parse() throws ParseException {
+		if (!this.parsed) {
+			file();
+			this.parsed = true;
+		}
+	}
+
+    public <S, I, A extends MutableNFA<S, I>> InputModelData<I, A> extract(AutomatonCreator<A, I> creator,
+																		   Function<String, I> symbolParser) {
+		Map<String, S> name2State = new HashMap<String, S>(HashUtil.capacity(this.states.size()));
+		Map<String, I> label2Input = new HashMap<String, I>(HashUtil.capacity(this.labels.size()));
+
+		final List<I> inputs = new ArrayList<I>(this.labels.size());
+        for (String l : this.labels) {
+			inputs.add(symbolParser.apply(l));
+        }
+		final Alphabet<I> alphabet = Alphabets.fromCollection(inputs);
+
+		final A nfa = creator.createAutomaton(alphabet, this.states.size());
+
+		for (String s : this.states) {
+			if (this.initials.contains(s)) {
+				name2State.put(s, nfa.addInitialState(this.finals.contains(s)));
+			} else {
+				name2State.put(s, nfa.addState(this.finals.contains(s)));
+			}
+		}
+		for (Triple<String, String, String> t : this.transitions) {
+			nfa.addTransition(name2State.get(t.getFirst()),
+							  label2Input.get(t.getSecond()),
+							  name2State.get(t.getThird()));
+        }
+
+        return new InputModelData<>(nfa, alphabet);
+    }
+}
+
+
+PARSER_END(ExplicitMataParser)
+
+SKIP :
+{
+	" "
+|	"\t"
+}
+
+TOKEN:
+{
+	< SECTION: "@NFA" >
+|	< ALPHABET: "%Alphabet" >
+|	< STATES: "%States" >
+|	< INITIAL: "%Initial" >
+|	< FINAL: "%Final" >
+|	< DASH: "-" >
+|	< NEWLINE : "\r" | "\n" | "\r\n">
+|	< STRING : (<LETTER> | <NUMBER>)+>
+|	< #LETTER: ["a"-"z","A"-"Z"] >
+|	< #NUMBER: ["0"-"9"] >
+}
+
+SKIP:
+{
+	< BEGIN_COMMENT: "#" > : IN_COMMENT
+}
+
+<IN_COMMENT> SKIP:
+{
+	< EOL : "\r" | "\n" | "\r\n" > : DEFAULT
+|	< ~[] >
+}
+
+
+private void file():
+{}
+{
+	{
+		this.labels = new LinkedHashSet<String>();
+		this.states = new LinkedHashSet<String>();
+		this.initials = new HashSet<String>();
+		this.finals = new HashSet<String>();
+		this.transitions = new ArrayList<Triple<String, String, String>>();
+	}
+	section() <NEWLINE>
+	(alphabet() <NEWLINE>)?
+	(states() <NEWLINE>)?
+	(initials() <NEWLINE>)?
+	(finals() <NEWLINE>)?
+	transitions() <EOF>
+}
+
+private void section():
+{}
+{
+	<SECTION>(<DASH><STRING>)?
+}
+
+private void alphabet():
+{
+	Token t;
+}
+{
+	<ALPHABET>(<DASH><STRING>)? (t = <STRING> { this.labels.add(t.toString()); })*
+}
+
+private void states():
+{
+	Token t;
+}
+{
+	<STATES>(<DASH><STRING>)? (t = <STRING> { this.states.add(t.toString()); })*
+}
+
+private void initials():
+{
+	Token t;
+}
+{
+	<INITIAL> (t = <STRING> { this.initials.add(t.toString()); })*
+}
+
+private void finals():
+{
+	Token t;
+}
+{
+	<FINAL> (t = <STRING> { this.finals.add(t.toString()); })*
+}
+
+private void transitions():
+{}
+{
+	(transition())*
+}
+
+private void transition():
+{
+	Token src;
+	Token input;
+	Token tgt;
+}
+{
+	src = <STRING> input = <STRING> tgt = <STRING> (<NEWLINE> | <EOF>)
+	{
+		String srcs = src.toString();
+		String inputs = input.toString();
+		String tgts = tgt.toString();
+		this.transitions.add(Triple.of(srcs, inputs, tgts));
+		this.labels.add(inputs);
+		this.states.add(srcs);
+		this.states.add(tgts);
+	}
+}

--- a/serialization/mata/src/main/javacc/mata-explicit.jj
+++ b/serialization/mata/src/main/javacc/mata-explicit.jj
@@ -45,10 +45,7 @@ import net.automatalib.common.util.Triple;
 import net.automatalib.exception.FormatException;
 import net.automatalib.serialization.InputModelData;
 
-public class ExplicitMataParser {
-
-	private NFA<?, Integer> nfa;
-	private Alphabet<Integer> alphabet;
+class ExplicitMataParser {
 
 	private Set<String> labels;
 	private Set<String> states;
@@ -56,7 +53,6 @@ public class ExplicitMataParser {
 	private Set<String> finals;
 	private List<Triple<String, String, String>> transitions;
 	private boolean parsed;
-
 
 	public void parse() throws ParseException {
 		if (!this.parsed) {
@@ -71,9 +67,11 @@ public class ExplicitMataParser {
 		Map<String, I> label2Input = new HashMap<String, I>(HashUtil.capacity(this.labels.size()));
 
 		final List<I> inputs = new ArrayList<I>(this.labels.size());
-        for (String l : this.labels) {
-			inputs.add(symbolParser.apply(l));
-        }
+		for (String l : this.labels) {
+			I i = symbolParser.apply(l);
+			inputs.add(i);
+			label2Input.put(l, i);
+		}
 		final Alphabet<I> alphabet = Alphabets.fromCollection(inputs);
 
 		final A nfa = creator.createAutomaton(alphabet, this.states.size());
@@ -95,7 +93,6 @@ public class ExplicitMataParser {
     }
 }
 
-
 PARSER_END(ExplicitMataParser)
 
 SKIP :
@@ -112,6 +109,7 @@ TOKEN:
 |	< INITIAL: "%Initial" >
 |	< FINAL: "%Final" >
 |	< DASH: "-" >
+|	< EXPLICIT: "explicit" >
 |	< NEWLINE : "\r" | "\n" | "\r\n">
 |	< STRING : (<LETTER> | <NUMBER>)+>
 |	< #LETTER: ["a"-"z","A"-"Z"] >
@@ -151,7 +149,7 @@ private void file():
 private void section():
 {}
 {
-	<SECTION>(<DASH><STRING>)?
+	<SECTION>(<DASH><EXPLICIT>)?
 }
 
 private void alphabet():

--- a/serialization/mata/src/test/java/net/automatalib/serialization/mata/MataSerializationTest.java
+++ b/serialization/mata/src/test/java/net/automatalib/serialization/mata/MataSerializationTest.java
@@ -19,7 +19,15 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.Function;
@@ -28,6 +36,9 @@ import net.automatalib.alphabet.Alphabet;
 import net.automatalib.alphabet.impl.Alphabets;
 import net.automatalib.automaton.fsa.impl.CompactDFA;
 import net.automatalib.automaton.fsa.impl.CompactNFA;
+import net.automatalib.common.util.IOUtil;
+import net.automatalib.common.util.io.UnclosableInputStream;
+import net.automatalib.common.util.io.UnclosableOutputStream;
 import net.automatalib.exception.FormatException;
 import net.automatalib.serialization.InputModelData;
 import net.automatalib.serialization.mata.parser.MataNFAParser;
@@ -40,38 +51,58 @@ import org.testng.annotations.Test;
 
 public class MataSerializationTest {
 
-    private static final Alphabet<Integer> INPUT_ALPHABET = Alphabets.integers(0, 3);
-    private static final int AUTOMATON_SIZE = 20;
-
     @Test
-    public void testSerialization() {
+    public void testSerialization() throws IOException, URISyntaxException {
+        final Alphabet<String> alphabet = Alphabets.closedCharStringRange('a', 'e');
+        final CompactNFA<String> nfa = TabakovVardiRandomAutomata.generateNFA(new Random(42), 5, 2, 5, alphabet);
 
+        final StringWriter sw = new StringWriter();
+        MataNFAWriter.write(sw, nfa, alphabet);
+
+        Path path =
+                Paths.get(Objects.requireNonNull(MataSerializationTest.class.getResource("/test-output.mata"))
+                                 .toURI());
+        String expected = Files.readString(path);
+
+        Assert.assertEquals(sw.toString(), expected);
     }
 
     @Test
     public void testDeserialization() throws IOException, FormatException {
-        try (InputStream is = MataSerializationTest.class.getResourceAsStream("/easy_basic-01-neg-all1-0.mata")) {
-            final MataNFAParser<?, String, CompactNFA<String>> reader =
-                    new MataNFAParser<>(new CompactNFA.Creator<>(), Function.identity());
+        try (Reader r = IOUtil.asBufferedUTF8Reader(MataSerializationTest.class.getResourceAsStream(
+                "/easy_basic-01-neg-all1-0.mata"))) {
 
-            final InputModelData<String, CompactNFA<String>> model = reader.readModel(is);
+            final InputModelData<String, CompactNFA<String>> model =
+                    MataNFAParser.parse(r, new CompactNFA.Creator<>(), Function.identity());
             final Alphabet<String> alphabet = model.alphabet;
             final CompactNFA<String> nfa = model.model;
 
             Assert.assertEquals(new HashSet<>(alphabet), Set.of("0", "1"));
             Assert.assertEquals(nfa.size(), 5);
-            Assert.assertEquals(nfa.getInitialStates().size(), 2);
-            Assert.assertEquals((int) nfa.getStates().stream().filter(nfa::isAccepting).count(), 2);
+            Assert.assertEquals(nfa.getInitialStates().size(), 1);
+            Assert.assertEquals(nfa.getStates().stream().filter(nfa::isAccepting).count(), 2);
+        }
+    }
+
+    @Test
+    public void testFailOnWrongFormat() throws IOException {
+        try (InputStream is = MataSerializationTest.class.getResourceAsStream("/false-T10-lhs.mata")) {
+            final MataNFAParser<?, String, CompactNFA<String>> reader =
+                    new MataNFAParser<>(new CompactNFA.Creator<>(), Function.identity());
+
+            Assert.assertThrows(FormatException.class, () -> reader.readModel(is));
         }
     }
 
     @Test
     public void testEquivalence() throws IOException, FormatException {
+        final Alphabet<Integer> alphabet = Alphabets.integers(0, 3);
+        final int size = 20;
 
-        final CompactNFA<Integer> nfa = new CompactNFA<>(INPUT_ALPHABET, AUTOMATON_SIZE + 2);
+        final CompactNFA<Integer> nfa = new CompactNFA<>(alphabet, size + 2);
 
         // use reduced alphabet
-        TabakovVardiRandomAutomata.generateNFA(new Random(42), AUTOMATON_SIZE, 2, 5, Alphabets.integers(0, 2), nfa);
+        TabakovVardiRandomAutomata.generateNFA(new Random(42), size, 2, 5, Alphabets.integers(0, 2), nfa);
         // add non-reachable state
         nfa.addState(true);
         nfa.addInitialState();
@@ -87,12 +118,33 @@ public class MataSerializationTest {
         final ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
         InputModelData<Integer, CompactNFA<Integer>> model = reader.readModel(bais);
 
-        Assert.assertEquals(model.alphabet, INPUT_ALPHABET);
+        Assert.assertEquals(model.alphabet, alphabet);
         Assert.assertEquals(model.model.size(), nfa.size());
 
         final CompactDFA<Integer> dfa1 = NFAs.determinize(nfa, false, false);
         final CompactDFA<Integer> dfa2 = NFAs.determinize(model.model, false, false);
 
-        Assert.assertTrue(Automata.testEquivalence(dfa1, dfa2, INPUT_ALPHABET));
+        Assert.assertTrue(Automata.testEquivalence(dfa1, dfa2, alphabet));
+    }
+
+    @Test
+    public void doNotCloseOutputStreamTest() throws IOException {
+        CompactNFA<Integer> nfa =
+                TabakovVardiRandomAutomata.generateNFA(new Random(42), 10, 2, 5, Alphabets.integers(0, 3));
+
+        // assert not throws
+        new MataNFAWriter<Integer>().writeModel(new UnclosableOutputStream(OutputStream.nullOutputStream()),
+                                                nfa,
+                                                nfa.getInputAlphabet());
+    }
+
+    @Test
+    public void doNotCloseInputStreamTest() throws IOException, FormatException {
+        try (InputStream is = MataSerializationTest.class.getResourceAsStream("/easy_basic-01-neg-all1-0.mata")) {
+            final MataNFAParser<?, ?, ?> reader =
+                    new MataNFAParser<>(new CompactNFA.Creator<>(), Function.identity());
+            // assert not throws
+            reader.readModel(new UnclosableInputStream(is));
+        }
     }
 }

--- a/serialization/mata/src/test/java/net/automatalib/serialization/mata/MataSerializationTest.java
+++ b/serialization/mata/src/test/java/net/automatalib/serialization/mata/MataSerializationTest.java
@@ -1,0 +1,98 @@
+/* Copyright (C) 2013-2025 TU Dortmund University
+ * This file is part of AutomataLib <https://automatalib.net>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.automatalib.serialization.mata;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+import java.util.function.Function;
+
+import net.automatalib.alphabet.Alphabet;
+import net.automatalib.alphabet.impl.Alphabets;
+import net.automatalib.automaton.fsa.impl.CompactDFA;
+import net.automatalib.automaton.fsa.impl.CompactNFA;
+import net.automatalib.exception.FormatException;
+import net.automatalib.serialization.InputModelData;
+import net.automatalib.serialization.mata.parser.MataNFAParser;
+import net.automatalib.serialization.mata.writer.MataNFAWriter;
+import net.automatalib.util.automaton.Automata;
+import net.automatalib.util.automaton.fsa.NFAs;
+import net.automatalib.util.automaton.random.TabakovVardiRandomAutomata;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class MataSerializationTest {
+
+    private static final Alphabet<Integer> INPUT_ALPHABET = Alphabets.integers(0, 3);
+    private static final int AUTOMATON_SIZE = 20;
+
+    @Test
+    public void testSerialization() {
+
+    }
+
+    @Test
+    public void testDeserialization() throws IOException, FormatException {
+        try (InputStream is = MataSerializationTest.class.getResourceAsStream("/easy_basic-01-neg-all1-0.mata")) {
+            final MataNFAParser<?, String, CompactNFA<String>> reader =
+                    new MataNFAParser<>(new CompactNFA.Creator<>(), Function.identity());
+
+            final InputModelData<String, CompactNFA<String>> model = reader.readModel(is);
+            final Alphabet<String> alphabet = model.alphabet;
+            final CompactNFA<String> nfa = model.model;
+
+            Assert.assertEquals(new HashSet<>(alphabet), Set.of("0", "1"));
+            Assert.assertEquals(nfa.size(), 5);
+            Assert.assertEquals(nfa.getInitialStates().size(), 2);
+            Assert.assertEquals((int) nfa.getStates().stream().filter(nfa::isAccepting).count(), 2);
+        }
+    }
+
+    @Test
+    public void testEquivalence() throws IOException, FormatException {
+
+        final CompactNFA<Integer> nfa = new CompactNFA<>(INPUT_ALPHABET, AUTOMATON_SIZE + 2);
+
+        // use reduced alphabet
+        TabakovVardiRandomAutomata.generateNFA(new Random(42), AUTOMATON_SIZE, 2, 5, Alphabets.integers(0, 2), nfa);
+        // add non-reachable state
+        nfa.addState(true);
+        nfa.addInitialState();
+
+        final MataNFAWriter<Integer> writer = new MataNFAWriter<>();
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        writer.writeModel(baos, nfa, nfa.getInputAlphabet());
+
+        final MataNFAParser<Integer, Integer, CompactNFA<Integer>> reader =
+                new MataNFAParser<>(new CompactNFA.Creator<>(), Integer::parseInt);
+
+        final ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        InputModelData<Integer, CompactNFA<Integer>> model = reader.readModel(bais);
+
+        Assert.assertEquals(model.alphabet, INPUT_ALPHABET);
+        Assert.assertEquals(model.model.size(), nfa.size());
+
+        final CompactDFA<Integer> dfa1 = NFAs.determinize(nfa, false, false);
+        final CompactDFA<Integer> dfa2 = NFAs.determinize(model.model, false, false);
+
+        Assert.assertTrue(Automata.testEquivalence(dfa1, dfa2, INPUT_ALPHABET));
+    }
+}

--- a/serialization/mata/src/test/resources/easy_basic-01-neg-all1-0.mata
+++ b/serialization/mata/src/test/resources/easy_basic-01-neg-all1-0.mata
@@ -1,0 +1,18 @@
+# example from https://github.com/VeriFIT/nfa-bench
+@NFA-explicit
+%Alphabet-auto
+%Initial q0
+%Final q4 q1
+q0 0 q1
+q0 1 q1
+q1 0 q1
+q1 0 q4
+q1 1 q2
+q2 0 q1
+q2 0 q4
+q2 1 q1
+q2 1 q3
+q3 0 q3
+q3 1 q3
+q4 0 q4
+q4 1 q4

--- a/serialization/mata/src/test/resources/false-T10-lhs.mata
+++ b/serialization/mata/src/test/resources/false-T10-lhs.mata
@@ -1,0 +1,17 @@
+# example from https://github.com/VeriFIT/nfa-bench
+@NFA-bits
+%Initial q0
+%Final q1
+q0 (!a1 & a2 & a3 & a4 & !a5) q3
+q0 (a1 & !a2 & a3 & a4 & !a5) q3
+q1 (a1 & a2 & a3 & a4 & a5) q1
+q1 (!a1 & a2 & a3 & a4 & a5) q1
+q1 (a1 & !a2 & a3 & a4 & a5) q1
+q1 (a1 & a2 & !a3 & a4 & a5) q1
+q1 (a1 & a2 & a3 & !a4 & a5) q1
+q1 (!a1 & a2 & a3 & a4 & !a5) q1
+q1 (a1 & !a2 & a3 & a4 & !a5) q1
+q2 (!a1 & a2 & a3 & a4 & !a5) q1
+q2 (a1 & !a2 & a3 & a4 & !a5) q1
+q3 (!a1 & a2 & a3 & a4 & !a5) q2
+q3 (a1 & !a2 & a3 & a4 & !a5) q2

--- a/serialization/mata/src/test/resources/test-output.mata
+++ b/serialization/mata/src/test/resources/test-output.mata
@@ -1,0 +1,15 @@
+@NFA-explicit
+%Alphabet 0 1 2 3 4
+%States q0 q1 q2 q3 q4
+%Initial q0
+%Final q0 q1 q2 q3 q4
+q0 0 q0
+q0 3 q2
+q1 2 q2
+q2 3 q4
+q2 4 q2
+q3 0 q3
+q3 1 q2
+q3 1 q3
+q3 2 q3
+q3 4 q2

--- a/serialization/pom.xml
+++ b/serialization/pom.xml
@@ -38,6 +38,7 @@ limitations under the License.
         <module>etf</module>
         <module>fsm</module>
         <module>learnlibv2</module>
+        <module>mata</module>
         <module>saf</module>
         <module>taf</module>
     </modules>


### PR DESCRIPTION
This PR adds a new `automata-serialization-mata` module that provides support for reading and writing NFAs in the (explicit) NFA format by the [mata library](https://github.com/VeriFIT/mata).