### PR TITLE
Add conformance test generators based on k-way state/transition coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added a new `automata-serialization-mata` module for serializing (explicit) NFAs in the `.mata` format as used by the [mata library](https://github.com/VeriFIT/mata).
 * `automata-modelchecking-m3c` now supports ARM-based macOS systems.
 * `automata-modelchecking-m3c` can now be included in jlink images.
+* Added `KWay{State,Transition}CoverTestsIterator`s to `automata-util` as a new means for conformance testing.
+* Added `CollectionUtil#allCombintationsIterator` and `CollectionUtil#allPermutationsIterator` for computing k-combinations and k-permutations.
 
 ### Changed
 

--- a/commons/util/src/main/java/net/automatalib/common/util/array/ArrayUtil.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/array/ArrayUtil.java
@@ -163,7 +163,17 @@ public final class ArrayUtil {
         }
     }
 
-    private static void swap(int[] arr, int i, int j) {
+    /**
+     * Swaps the two elements at the given position in-place.
+     *
+     * @param arr
+     *         the array
+     * @param i
+     *         the first index
+     * @param j
+     *         the second index
+     */
+    public static void swap(int[] arr, int i, int j) {
         int tmp = arr[i];
         arr[i] = arr[j];
         arr[j] = tmp;

--- a/commons/util/src/main/java/net/automatalib/common/util/collection/AllCombinationsIterator.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/collection/AllCombinationsIterator.java
@@ -15,84 +15,85 @@
  */
 package net.automatalib.common.util.collection;
 
-import java.util.ArrayList;
-import java.util.Iterator;
+import java.util.AbstractList;
+import java.util.Collection;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 /**
- * An iterator that iterates over the cartesian product of its given source domains. Each intermediate combination of
- * elements is computed lazily.
- * <p>
- * <b>Note:</b> Subsequent calls to the {@link #next()} method return a reference to the same list, and only update the
- * contents of the list. If you plan to reuse intermediate results, you'll need to explicitly copy them.
+ * Iterator for computing all k-combinations of a given collection. Implementation is based on <a
+ * href="https://hmkcode.com/calculate-find-all-possible-combinations-of-an-array-using-java/">https://hmkcode.com/calculate-find-all-possible-combinations-of-an-array-using-java/</a>.
  *
  * @param <T>
- *         type of elements
+ *         element type
  */
-final class AllCombinationsIterator<T> implements Iterator<List<T>> {
+final class AllCombinationsIterator<T> extends AbstractSimplifiedIterator<List<T>> {
 
-    private final Iterable<? extends T>[] iterables;
-    private final Iterator<? extends T>[] iterators;
-    private final List<T> current;
-    private boolean first = true;
-    private boolean empty;
+    private final int[] pointers;
+    private final int n;
+    private final int k;
 
-    @SuppressWarnings("unchecked")
-    @SafeVarargs
-    AllCombinationsIterator(Iterable<? extends T>... iterables) {
-        this.iterables = iterables;
-        this.iterators = new Iterator[iterables.length];
-        this.current = new ArrayList<>(iterables.length);
-        for (int i = 0; i < iterators.length; i++) {
-            Iterator<? extends T> it = iterables[i].iterator();
-            if (!it.hasNext()) {
-                empty = true;
-                break;
-            }
-            this.iterators[i] = it;
-            this.current.add(it.next());
+    private int r; // index for combination array
+    private int i; // index for elements array
+
+    AllCombinationsIterator(Collection<? extends T> elements, int k) {
+        if (k < 0 || k > elements.size()) {
+            throw new IllegalArgumentException("k is not within its expected bounds of 0 and " + elements.size());
         }
+
+        this.n = elements.size();
+        this.k = k;
+
+        // we only read this array
+        @SuppressWarnings({"unchecked", "PMD.ClassCastExceptionWithToArray"})
+        final T[] pool = (T[]) elements.toArray();
+        this.pointers = new int[k];
+
+        // always use same instance which is modified in-place
+        super.nextValue = new MappedList<>(pool, this.pointers, this.k);
     }
 
     @Override
-    public boolean hasNext() {
-        if (empty) {
-            return false;
-        }
-
-        for (Iterator<? extends T> it : iterators) {
-            if (it.hasNext()) {
-                return true;
+    protected boolean calculateNext() {
+        while (r >= 0) {
+            if (i <= n + r - k) { // forward step if i < (n + (r-K))
+                pointers[r] = i;
+                if (r == k - 1) { // if combination array is full print and increment i;
+                    i++;
+                    return true;
+                } else { // if combination is not full yet, select next element
+                    i = pointers[r] + 1;
+                    r++;
+                }
+            } else { // backward step
+                r--;
+                if (r >= 0) {
+                    i = pointers[r] + 1;
+                }
             }
         }
-
-        return first;
+        return false;
     }
 
-    @Override
-    public List<T> next() {
-        if (empty) {
-            throw new NoSuchElementException();
-        } else if (first) {
-            first = false;
-            return current;
+    static class MappedList<T> extends AbstractList<T> {
+
+        private final T[] pool;
+        private final int[] pointers;
+        private final int k;
+
+        MappedList(T[] pool, int[] pointers, int k) {
+            this.pool = pool;
+            this.pointers = pointers;
+            this.k = k;
         }
 
-        for (int i = 0; i < iterators.length; i++) {
-            Iterator<? extends T> it = iterators[i];
-
-            if (iterators[i].hasNext()) {
-                current.set(i, it.next());
-                return current;
-            }
-
-            it = iterables[i].iterator();
-            iterators[i] = it;
-            current.set(i, it.next());
+        @Override
+        public T get(int index) {
+            return pool[pointers[index]];
         }
 
-        throw new NoSuchElementException();
+        @Override
+        public int size() {
+            return k;
+        }
     }
-
 }

--- a/commons/util/src/main/java/net/automatalib/common/util/collection/AllPermutationsIterator.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/collection/AllPermutationsIterator.java
@@ -1,0 +1,88 @@
+/* Copyright (C) 2013-2025 TU Dortmund University
+ * This file is part of AutomataLib <https://automatalib.net>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.automatalib.common.util.collection;
+
+import java.util.Collection;
+import java.util.List;
+
+import net.automatalib.common.util.array.ArrayUtil;
+import net.automatalib.common.util.collection.AllCombinationsIterator.MappedList;
+
+/**
+ * Iterator for computing all k-permutations of a given collection. Implementation is based on <a
+ * href="https://docs.python.org/3/library/itertools.html#itertools.permutations">itertools.permutations</a>.
+ *
+ * @param <T>
+ *         element type
+ */
+final class AllPermutationsIterator<T> extends AbstractSimplifiedIterator<List<T>> {
+
+    private final int n;
+    private final int[] indices;
+    private final int[] cycles;
+    private final int r;
+
+    private boolean initial;
+
+    AllPermutationsIterator(Collection<? extends T> elements, int k) {
+        if (k < 0 || k > elements.size()) {
+            throw new IllegalArgumentException("k is not within its expected bounds of 0 and " + elements.size());
+        }
+
+        this.n = elements.size();
+        this.r = k;
+
+        // we only read this array
+        @SuppressWarnings({"unchecked", "PMD.ClassCastExceptionWithToArray"})
+        final T[] pool = (T[]) elements.toArray();
+        this.indices = new int[this.n];
+        this.cycles = new int[k];
+
+        for (int j = 0; j < n; j++) {
+            indices[j] = j;
+            if (j < k) {
+                cycles[j] = n - j;
+            }
+        }
+
+        // always use same instance which is modified in-place
+        super.nextValue = new MappedList<>(pool, this.indices, k);
+    }
+
+    @Override
+    protected boolean calculateNext() {
+        if (!initial) { // the first element is the unaltered one
+            initial = true;
+            return true;
+        }
+
+        for (int i = r - 1; i >= 0; i--) {
+            cycles[i] -= 1;
+            if (cycles[i] == 0) {
+                int old = indices[i];
+                System.arraycopy(indices, i + 1, indices, i, n - i - 1);
+                indices[n - 1] = old;
+                cycles[i] = n - i;
+            } else {
+                int j = cycles[i];
+                ArrayUtil.swap(indices, i, n - j);
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/commons/util/src/main/java/net/automatalib/common/util/collection/CartesianProductIterator.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/collection/CartesianProductIterator.java
@@ -1,0 +1,98 @@
+/* Copyright (C) 2013-2025 TU Dortmund University
+ * This file is part of AutomataLib <https://automatalib.net>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.automatalib.common.util.collection;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * An iterator that iterates over the cartesian product of its given source domains. Each intermediate combination of
+ * elements is computed lazily.
+ * <p>
+ * <b>Note:</b> Subsequent calls to the {@link #next()} method return a reference to the same list, and only update the
+ * contents of the list. If you plan to reuse intermediate results, you'll need to explicitly copy them.
+ *
+ * @param <T>
+ *         type of elements
+ */
+final class CartesianProductIterator<T> implements Iterator<List<T>> {
+
+    private final Iterable<? extends T>[] iterables;
+    private final Iterator<? extends T>[] iterators;
+    private final List<T> current;
+    private boolean first = true;
+    private boolean empty;
+
+    @SuppressWarnings("unchecked")
+    @SafeVarargs
+    CartesianProductIterator(Iterable<? extends T>... iterables) {
+        this.iterables = iterables;
+        this.iterators = new Iterator[iterables.length];
+        this.current = new ArrayList<>(iterables.length);
+        for (int i = 0; i < iterators.length; i++) {
+            Iterator<? extends T> it = iterables[i].iterator();
+            if (!it.hasNext()) {
+                empty = true;
+                break;
+            }
+            this.iterators[i] = it;
+            this.current.add(it.next());
+        }
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (empty) {
+            return false;
+        }
+
+        for (Iterator<? extends T> it : iterators) {
+            if (it.hasNext()) {
+                return true;
+            }
+        }
+
+        return first;
+    }
+
+    @Override
+    public List<T> next() {
+        if (empty) {
+            throw new NoSuchElementException();
+        } else if (first) {
+            first = false;
+            return current;
+        }
+
+        for (int i = 0; i < iterators.length; i++) {
+            Iterator<? extends T> it = iterators[i];
+
+            if (iterators[i].hasNext()) {
+                current.set(i, it.next());
+                return current;
+            }
+
+            it = iterables[i].iterator();
+            iterators[i] = it;
+            current.set(i, it.next());
+        }
+
+        throw new NoSuchElementException();
+    }
+
+}

--- a/commons/util/src/main/java/net/automatalib/common/util/collection/CartesianProductIterator.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/collection/CartesianProductIterator.java
@@ -35,7 +35,7 @@ final class CartesianProductIterator<T> implements Iterator<List<T>> {
     private final Iterable<? extends T>[] iterables;
     private final Iterator<? extends T>[] iterators;
     private final List<T> current;
-    private boolean first = true;
+    private boolean first;
     private boolean empty;
 
     @SuppressWarnings("unchecked")
@@ -44,6 +44,8 @@ final class CartesianProductIterator<T> implements Iterator<List<T>> {
         this.iterables = iterables;
         this.iterators = new Iterator[iterables.length];
         this.current = new ArrayList<>(iterables.length);
+        this.first = true;
+
         for (int i = 0; i < iterators.length; i++) {
             Iterator<? extends T> it = iterables[i].iterator();
             if (!it.hasNext()) {

--- a/commons/util/src/main/java/net/automatalib/common/util/collection/CollectionUtil.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/collection/CollectionUtil.java
@@ -56,6 +56,67 @@ public final class CollectionUtil {
     }
 
     /**
+     * Return {@code k}-length subsequences of elements from the input collection.
+     * <p>
+     * <b>Note:</b>
+     * Elements are treated as unique based on their position, not on their value. If the input elements are unique,
+     * there will be no repeated values within each combination. Subsequent calls to the returned iterator's
+     * {@link Iterator#next() next()} method return a reference to the same list, and only update the contents of the
+     * list. If you plan to reuse intermediate results, you'll need to explicitly copy them.
+     *
+     * @param elements
+     *         the collection for the source elements
+     * @param k
+     *         the length of the (partial) combination
+     * @param <T>
+     *         type of elements
+     *
+     * @return an iterator iterating over all k-combinations
+     */
+    public static <T> Iterator<List<T>> allCombintationsIterator(Collection<? extends T> elements, int k) {
+        return new AllCombinationsIterator<>(elements, k);
+    }
+
+    /**
+     * Convenience method for {@link #allPermutationsIterator(Collection, int)} which uses the number of elements as
+     * {@code k}.
+     *
+     * @param elements
+     *         the collection for the source elements
+     * @param <T>
+     *         type of elements
+     *
+     * @return an iterator iterating over all k-permutations
+     *
+     * @see #allPermutationsIterator(Collection, int)
+     */
+    public static <T> Iterator<List<T>> allPermutationsIterator(Collection<? extends T> elements) {
+        return allPermutationsIterator(elements, elements.size());
+    }
+
+    /**
+     * Return {@code k}-length permutations of elements from the input collection.
+     * <p>
+     * <b>Note:</b>
+     * Elements are treated as unique based on their position, not on their value. If the input elements are unique,
+     * there will be no repeated values within each permutation. Subsequent calls to the returned iterator's
+     * {@link Iterator#next() next()} method return a reference to the same list, and only update the contents of the
+     * list. If you plan to reuse intermediate results, you'll need to explicitly copy them.
+     *
+     * @param elements
+     *         the collection for the source elements
+     * @param k
+     *         the length of the (partial) permutation
+     * @param <T>
+     *         type of elements
+     *
+     * @return an iterator iterating over all k-permutations
+     */
+    public static <T> Iterator<List<T>> allPermutationsIterator(Collection<? extends T> elements, int k) {
+        return new AllPermutationsIterator<>(elements, k);
+    }
+
+    /**
      * Returns a (mutable) view on the given collection that transforms its elements as specified by the given mapping.
      *
      * @param collection

--- a/commons/util/src/main/java/net/automatalib/common/util/collection/IterableUtil.java
+++ b/commons/util/src/main/java/net/automatalib/common/util/collection/IterableUtil.java
@@ -31,6 +31,22 @@ public final class IterableUtil {
         // prevent instantiation
     }
 
+    /**
+     * Convenience method for {@link #allTuples(Iterable, int, int)} that uses {@code length} for both {@code minLength}
+     * and {@code maxLength}.
+     *
+     * @param domain
+     *         the iterables for the source domain
+     * @param length
+     *         the minimal length of the tuple
+     * @param <T>
+     *         type of elements
+     *
+     * @return an iterator that iterates over all tuples of the given source domain whose length (dimension) is the
+     * given parameter
+     *
+     * @see #allTuples(Iterable, int, int)
+     */
     public static <T> Iterable<List<T>> allTuples(Iterable<? extends T> domain, int length) {
         return allTuples(domain, length, length);
     }
@@ -44,7 +60,7 @@ public final class IterableUtil {
      * you'll need to explicitly copy them.
      *
      * @param domain
-     *         the iterables for the source domains
+     *         the iterables for the source domain
      * @param minLength
      *         the minimal length of the tuple
      * @param maxLength
@@ -90,7 +106,7 @@ public final class IterableUtil {
             return Collections.singletonList(Collections.emptyList());
         }
 
-        return () -> new AllCombinationsIterator<>(iterables);
+        return () -> new CartesianProductIterator<>(iterables);
     }
 
     /**

--- a/commons/util/src/test/java/net/automatalib/common/util/collection/CollectionUtilTest.java
+++ b/commons/util/src/test/java/net/automatalib/common/util/collection/CollectionUtilTest.java
@@ -15,13 +15,20 @@
  */
 package net.automatalib.common.util.collection;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class CollectionUtilTest {
+
+    private static final List<Character> COLLECTION = Arrays.asList('A', 'B', 'C', 'D');
 
     @Test
     public void testAdd() {
@@ -32,5 +39,159 @@ public class CollectionUtilTest {
         Assert.assertEquals(set, elements);
         Assert.assertFalse(CollectionUtil.add(set, elements.iterator()));
         Assert.assertEquals(set, elements);
+    }
+
+    @Test
+    public void testIllegalPermutations() {
+        Assert.assertThrows(IllegalArgumentException.class,
+                            () -> CollectionUtil.allPermutationsIterator(COLLECTION, -1));
+        Assert.assertThrows(IllegalArgumentException.class,
+                            () -> CollectionUtil.allPermutationsIterator(COLLECTION, 5));
+    }
+
+    @Test
+    public void testAllTwoPermutations() {
+        final int k = 2;
+        final Iterator<List<Character>> lists = CollectionUtil.allPermutationsIterator(COLLECTION, k);
+        final List<String> tuples = new ArrayList<>();
+
+        while (lists.hasNext()) {
+            StringBuilder sb = new StringBuilder(k);
+            lists.next().forEach(sb::append);
+            Assert.assertTrue(tuples.add(sb.toString()));
+        }
+
+        Assert.assertEquals(tuples,
+                            Arrays.asList("AB", "AC", "AD", "BA", "BC", "BD", "CA", "CB", "CD", "DA", "DB", "DC"));
+    }
+
+    @Test
+    public void testAllThreePermutations() {
+        final int k = 3;
+        final Iterator<List<Character>> lists = CollectionUtil.allPermutationsIterator(COLLECTION, k);
+        final List<String> tuples = new ArrayList<>();
+
+        while (lists.hasNext()) {
+            StringBuilder sb = new StringBuilder(k);
+            lists.next().forEach(sb::append);
+            Assert.assertTrue(tuples.add(sb.toString()));
+        }
+
+        Assert.assertEquals(tuples,
+                            Arrays.asList("ABC",
+                                          "ABD",
+                                          "ACB",
+                                          "ACD",
+                                          "ADB",
+                                          "ADC",
+                                          "BAC",
+                                          "BAD",
+                                          "BCA",
+                                          "BCD",
+                                          "BDA",
+                                          "BDC",
+                                          "CAB",
+                                          "CAD",
+                                          "CBA",
+                                          "CBD",
+                                          "CDA",
+                                          "CDB",
+                                          "DAB",
+                                          "DAC",
+                                          "DBA",
+                                          "DBC",
+                                          "DCA",
+                                          "DCB"));
+    }
+
+    @Test
+    public void testAllFourPermutations() {
+        final int n = COLLECTION.size();
+        final Iterator<List<Character>> lists = CollectionUtil.allPermutationsIterator(COLLECTION);
+        final List<String> tuples = new ArrayList<>();
+
+        while (lists.hasNext()) {
+            StringBuilder sb = new StringBuilder(n);
+            lists.next().forEach(sb::append);
+            Assert.assertTrue(tuples.add(sb.toString()));
+        }
+
+        final List<String> expected = new ArrayList<>();
+        // brute-force 4 dimensional tuples
+        for (int i1 = 0; i1 < n; i1++) {
+            for (int i2 = 0; i2 < n; i2++) {
+                if (i1 != i2) {
+                    for (int i3 = 0; i3 < n; i3++) {
+                        if (i3 != i1 && i3 != i2) {
+                            for (int i4 = 0; i4 < n; i4++) {
+                                if (i4 != i1 && i4 != i2 && i4 != i3) {
+                                    final StringBuilder sb = new StringBuilder();
+                                    sb.append(COLLECTION.get(i1))
+                                      .append(COLLECTION.get(i2))
+                                      .append(COLLECTION.get(i3))
+                                      .append(COLLECTION.get(i4));
+                                    expected.add(sb.toString());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Assert.assertEquals(tuples, expected);
+    }
+
+    @Test
+    public void testIllegalCombinations() {
+        Assert.assertThrows(IllegalArgumentException.class,
+                            () -> CollectionUtil.allCombintationsIterator(COLLECTION, -1));
+        Assert.assertThrows(IllegalArgumentException.class,
+                            () -> CollectionUtil.allCombintationsIterator(COLLECTION, 5));
+    }
+
+    @Test
+    public void testAllTwoCombinations() {
+        final int k = 2;
+        final Iterator<List<Character>> lists = CollectionUtil.allCombintationsIterator(COLLECTION, k);
+        final List<String> tuples = new ArrayList<>();
+
+        while (lists.hasNext()) {
+            StringBuilder sb = new StringBuilder(k);
+            lists.next().forEach(sb::append);
+            Assert.assertTrue(tuples.add(sb.toString()));
+        }
+
+        Assert.assertEquals(tuples, Arrays.asList("AB", "AC", "AD", "BC", "BD", "CD"));
+    }
+
+    @Test
+    public void testAllThreeCombinations() {
+        final int k = 3;
+        final Iterator<List<Character>> lists = CollectionUtil.allCombintationsIterator(COLLECTION, k);
+        final List<String> tuples = new ArrayList<>();
+
+        while (lists.hasNext()) {
+            StringBuilder sb = new StringBuilder(k);
+            lists.next().forEach(sb::append);
+            Assert.assertTrue(tuples.add(sb.toString()));
+        }
+
+        Assert.assertEquals(tuples, Arrays.asList("ABC", "ABD", "ACD", "BCD"));
+    }
+
+    @Test
+    public void testAllFourCombinations() {
+        final int k = 4;
+        final Iterator<List<Character>> lists = CollectionUtil.allCombintationsIterator(COLLECTION, k);
+        final List<String> tuples = new ArrayList<>();
+
+        while (lists.hasNext()) {
+            StringBuilder sb = new StringBuilder(k);
+            lists.next().forEach(sb::append);
+            Assert.assertTrue(tuples.add(sb.toString()));
+        }
+
+        Assert.assertEquals(tuples, Collections.singleton("ABCD"));
     }
 }

--- a/commons/util/src/test/java/net/automatalib/common/util/collection/IteratableUtilTest.java
+++ b/commons/util/src/test/java/net/automatalib/common/util/collection/IteratableUtilTest.java
@@ -16,7 +16,11 @@
 package net.automatalib.common.util.collection;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -33,5 +37,23 @@ public class IteratableUtilTest {
 
         Assert.assertEquals(concat1, Arrays.asList(1, 2, 4, 3));
         Assert.assertEquals(concat2, Arrays.asList(4, 3, 1, 2));
+    }
+
+    @Test
+    public void testExhaustiveness() {
+
+        Set<Integer> iterable = Collections.singleton(1);
+        Iterator<List<Integer>> iter1 = IterableUtil.cartesianProduct(iterable).iterator();
+        Iterator<List<Integer>> iter2 = IterableUtil.allTuples(iterable, 1, 1).iterator();
+
+        // consume iterators
+        IteratorUtil.size(iter1);
+        IteratorUtil.size(iter2);
+
+        Assert.assertFalse(iter1.hasNext());
+        Assert.assertThrows(NoSuchElementException.class, iter1::next);
+
+        Assert.assertFalse(iter2.hasNext());
+        Assert.assertThrows(NoSuchElementException.class, iter2::next);
     }
 }

--- a/commons/util/src/test/java/net/automatalib/common/util/collection/IteratorUtilTest.java
+++ b/commons/util/src/test/java/net/automatalib/common/util/collection/IteratorUtilTest.java
@@ -27,7 +27,7 @@ public class IteratorUtilTest {
 
     @Test
     public void testBatch() {
-        final Iterator<Integer> iterator = Stream.iterate(0, i -> i+1).limit(50).iterator();
+        final Iterator<Integer> iterator = Stream.iterate(0, i -> i + 1).limit(50).iterator();
         final Iterator<List<Integer>> batchIterator = IteratorUtil.batch(iterator, 20);
 
         Assert.assertTrue(batchIterator.hasNext());
@@ -39,7 +39,7 @@ public class IteratorUtilTest {
         Assert.assertFalse(batchIterator.hasNext());
         Assert.assertThrows(NoSuchElementException.class, batchIterator::next);
 
-        final Iterator<Integer> iterator2 = Stream.iterate(0, i -> i+1).limit(60).iterator();
+        final Iterator<Integer> iterator2 = Stream.iterate(0, i -> i + 1).limit(60).iterator();
         final Iterator<List<Integer>> batchIterator2 = IteratorUtil.batch(iterator2, 20);
 
         Assert.assertTrue(batchIterator2.hasNext());

--- a/util/src/main/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIterator.java
+++ b/util/src/main/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIterator.java
@@ -29,17 +29,35 @@ import net.automatalib.automaton.graph.TransitionEdge;
 import net.automatalib.common.util.HashUtil;
 import net.automatalib.common.util.collection.AbstractSimplifiedIterator;
 import net.automatalib.common.util.collection.CollectionUtil;
-import net.automatalib.common.util.collection.IterableUtil;
 import net.automatalib.common.util.collection.IteratorUtil;
+import net.automatalib.common.util.random.RandomUtil;
 import net.automatalib.util.graph.Graphs;
 import net.automatalib.util.graph.apsp.APSPResult;
 import net.automatalib.word.Word;
 import net.automatalib.word.WordBuilder;
 
+/**
+ * A randomized state cover test generator based on the concepts of mutation testing as described in the paper <a
+ * href="https://doi.org/10.1007/978-3-319-57288-8_2">Learning from Faults: Mutation Testing in Active Automata
+ * Learning</a> by Bernhard K. Aichernig and Martin Tappler.
+ * <p>
+ * A test case will be computed for every k-combination or k-permutation of states with additional random walk at the
+ * end.
+ *
+ * @param <S>
+ *         automaton state type
+ * @param <I>
+ *         input symbol type
+ * @param <T>
+ *         transition type
+ * @param <A>
+ *         automaton type
+ */
 public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>>
         implements Iterator<Word<I>> {
 
-    private static final int DEFAULT_RANDOM_WALK_LENGTH = 20;
+    public static final int DEFAULT_R_WALK_LEN = 20;
+    public static final int DEFAULT_K = 2;
 
     private final A automaton;
     private final List<? extends I> alphabet;
@@ -50,32 +68,74 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
 
     private final Iterator<Word<I>> iterator;
 
+    /**
+     * Convenience constructor which uses a fresh {@code random} object.
+     *
+     * @param automaton
+     *         the automaton for which to generate test cases
+     * @param inputs
+     *         the inputs to consider for test case generation
+     *
+     * @see #KWayStateCoverTestsIterator(UniversalDeterministicAutomaton, Collection, Random)
+     */
     public KWayStateCoverTestsIterator(A automaton, Collection<? extends I> inputs) {
         this(automaton, inputs, new Random());
     }
 
+    /**
+     * Convenience constructor. Uses {@code k=2}, {@code randomWalkLen = 20}, and
+     * {@code method = CombinationMethod.PERMUTATIONS}.
+     *
+     * @param automaton
+     *         the automaton for which to generate test cases
+     * @param inputs
+     *         the inputs to consider for test case generation
+     * @param random
+     *         the random number generator to use
+     *
+     * @see #KWayStateCoverTestsIterator(UniversalDeterministicAutomaton, Collection, Random, int, int,
+     * CombinationMethod)
+     */
     public KWayStateCoverTestsIterator(A automaton, Collection<? extends I> inputs, Random random) {
-        this(automaton, inputs, random, 2, DEFAULT_RANDOM_WALK_LENGTH, CombinationMethod.PERMUTATIONS);
+        this(automaton, inputs, random, DEFAULT_R_WALK_LEN, DEFAULT_K, CombinationMethod.PERMUTATIONS);
     }
 
+    /**
+     * Constructor.
+     *
+     * @param automaton
+     *         the automaton for which to generate test cases
+     * @param inputs
+     *         the inputs to consider for test case generation
+     * @param random
+     *         the random number generator to use
+     * @param randomWalkLen
+     *         length of random walk performed at the end of each combination/permutation
+     * @param k
+     *         k value used for k-wise combinations/permutations of states
+     * @param method
+     *         the method for computing combinations
+     */
     public KWayStateCoverTestsIterator(A automaton,
                                        Collection<? extends I> inputs,
                                        Random random,
-                                       int k,
                                        int randomWalkLen,
+                                       int k,
                                        CombinationMethod method) {
         this.automaton = automaton;
         this.alphabet = CollectionUtil.randomAccessList(inputs);
-        this.k = k;
+        this.k = Math.min(k, automaton.size());
         this.randomWalkLen = randomWalkLen;
         this.method = method;
         this.random = random;
 
-        if (automaton.size() == 0) {
+        final S initial = automaton.getInitialState();
+
+        if (automaton.size() == 0 || initial == null) {
             this.iterator = Collections.emptyIterator();
         } else {
             final FirstPhaseIterator firstIterator = new FirstPhaseIterator();
-            final SecondPhaseIterator secondPhaseIterator = new SecondPhaseIterator();
+            final SecondPhaseIterator secondPhaseIterator = new SecondPhaseIterator(initial);
             this.iterator = IteratorUtil.concat(firstIterator, secondPhaseIterator);
         }
     }
@@ -90,16 +150,6 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
         return iterator.next();
     }
 
-    static <I> Word<I> getRandomChoices(List<? extends I> alphabet, int count, Random random) {
-        WordBuilder<I> choices = new WordBuilder<>(count);
-
-        for (int i = 0; i < count; i++) {
-            choices.append(alphabet.get(random.nextInt(alphabet.size())));
-        }
-
-        return choices.toWord();
-    }
-
     /**
      * Performs random walks if the automaton only has a single state.
      */
@@ -110,7 +160,7 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
         @Override
         protected boolean calculateNext() {
             if (automaton.size() == 1 && idx++ < randomWalkLen) {
-                super.nextValue = getRandomChoices(alphabet, randomWalkLen, random);
+                super.nextValue = Word.fromList(RandomUtil.sample(random, alphabet, randomWalkLen));
                 return true;
             }
             return false;
@@ -124,10 +174,12 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
 
         private final Iterator<List<S>> combIter;
         private final Set<Set<List<TransitionEdge<I, T>>>> cache;
+        private final S initial;
 
         private APSPResult<S, TransitionEdge<I, T>> apsp;
 
-        SecondPhaseIterator() {
+        SecondPhaseIterator(S initial) {
+            this.initial = initial;
             List<S> states = new ArrayList<>(automaton.getStates());
             Collections.shuffle(states, random);
             this.combIter = method.getCombinations(states, k);
@@ -137,7 +189,6 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
         @Override
         protected boolean calculateNext() {
 
-            final S initial = automaton.getInitialState();
             final APSPResult<S, TransitionEdge<I, T>> apsp = getAPSP();
 
             while (combIter.hasNext()) {
@@ -166,7 +217,7 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
                  */
                 boolean possibleTestCase = true;
                 for (int index = 0; index < comb.size() - 1; index++) {
-                    final List<? extends TransitionEdge<I, ?>> pathBetweenStates =
+                    final List<TransitionEdge<I, T>> pathBetweenStates =
                             apsp.getShortestPath(comb.get(index), comb.get(index + 1));
 
                     if (pathBetweenStates == null || pathBetweenStates.isEmpty()) {
@@ -180,11 +231,7 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
                 }
 
                 if (possibleTestCase) {
-                    // Add random walk at the end
-                    for (I p : getRandomChoices(alphabet, randomWalkLen, random)) {
-                        pathBuilder.append(p);
-                    }
-
+                    pathBuilder.append(RandomUtil.sample(random, alphabet, randomWalkLen));
                     super.nextValue = pathBuilder.toWord();
                     return true;
                 }
@@ -206,17 +253,30 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
         }
     }
 
+    /**
+     * The specific method for generating combinations of states during exploration.
+     */
     public enum CombinationMethod {
+        /**
+         * Generate all k-combinations of states.
+         *
+         * @see CollectionUtil#allCombintationsIterator(Collection, int)
+         */
         COMBINATIONS {
             @Override
             <S> Iterator<List<S>> getCombinations(List<S> states, int k) {
-                throw new NoSuchMethodError("TODO");
+                return CollectionUtil.allCombintationsIterator(states, k);
             }
         },
+        /**
+         * Generate all k-permutations of states.
+         *
+         * @see CollectionUtil#allPermutationsIterator(Collection, int)
+         */
         PERMUTATIONS {
             @Override
             <S> Iterator<List<S>> getCombinations(List<S> states, int k) {
-                return IterableUtil.allTuples(states, k).iterator();
+                return CollectionUtil.allPermutationsIterator(states, k);
             }
         };
 

--- a/util/src/main/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIterator.java
+++ b/util/src/main/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIterator.java
@@ -63,8 +63,8 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
     private final A automaton;
     private final List<? extends I> alphabet;
     private final Random random;
-    private final int k;
     private final int randomWalkLen;
+    private final int k;
     private final CombinationMethod method;
 
     private final Iterator<Word<I>> iterator;
@@ -125,10 +125,10 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
                                        CombinationMethod method) {
         this.automaton = automaton;
         this.alphabet = CollectionUtil.randomAccessList(inputs);
-        this.k = Math.min(k, automaton.size());
-        this.randomWalkLen = randomWalkLen;
-        this.method = method;
         this.random = random;
+        this.randomWalkLen = randomWalkLen;
+        this.k = Math.min(k, automaton.size());
+        this.method = method;
 
         final S initial = automaton.getInitialState();
 

--- a/util/src/main/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIterator.java
+++ b/util/src/main/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIterator.java
@@ -1,3 +1,18 @@
+/* Copyright (C) 2013-2025 TU Dortmund University
+ * This file is part of AutomataLib <https://automatalib.net>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.automatalib.util.automaton.conformance;
 
 import java.util.ArrayList;
@@ -8,6 +23,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+
 import net.automatalib.automaton.UniversalDeterministicAutomaton;
 import net.automatalib.automaton.graph.TransitionEdge;
 import net.automatalib.common.util.HashUtil;
@@ -23,6 +39,8 @@ import net.automatalib.word.WordBuilder;
 public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>>
         implements Iterator<Word<I>> {
 
+    private static final int DEFAULT_RANDOM_WALK_LENGTH = 20;
+
     private final A automaton;
     private final List<? extends I> alphabet;
     private final Random random;
@@ -37,7 +55,7 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
     }
 
     public KWayStateCoverTestsIterator(A automaton, Collection<? extends I> inputs, Random random) {
-        this(automaton, inputs, random, 2, 20, CombinationMethod.Permutations);
+        this(automaton, inputs, random, 2, DEFAULT_RANDOM_WALK_LENGTH, CombinationMethod.PERMUTATIONS);
     }
 
     public KWayStateCoverTestsIterator(A automaton,
@@ -76,7 +94,7 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
         WordBuilder<I> choices = new WordBuilder<>(count);
 
         for (int i = 0; i < count; i++) {
-            choices.add(alphabet.get(random.nextInt(alphabet.size())));
+            choices.append(alphabet.get(random.nextInt(alphabet.size())));
         }
 
         return choices.toWord();
@@ -87,15 +105,13 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
      */
     private final class FirstPhaseIterator extends AbstractSimplifiedIterator<Word<I>> {
 
-        private int idx = 0;
+        private int idx;
 
         @Override
         protected boolean calculateNext() {
-            if (automaton.size() == 1) {
-                if (idx++ < randomWalkLen) {
-                    super.nextValue = getRandomChoices(alphabet, randomWalkLen, random);
-                    return true;
-                }
+            if (automaton.size() == 1 && idx++ < randomWalkLen) {
+                super.nextValue = getRandomChoices(alphabet, randomWalkLen, random);
+                return true;
             }
             return false;
         }
@@ -111,7 +127,7 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
 
         private APSPResult<S, TransitionEdge<I, T>> apsp;
 
-        public SecondPhaseIterator() {
+        SecondPhaseIterator() {
             List<S> states = new ArrayList<>(automaton.getStates());
             Collections.shuffle(states, random);
             this.combIter = method.getCombinations(states, k);
@@ -141,7 +157,7 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
 
                 final WordBuilder<I> pathBuilder = new WordBuilder<>();
                 for (TransitionEdge<I, T> e : firstPath) {
-                    pathBuilder.add(e.getInput());
+                    pathBuilder.append(e.getInput());
                 }
 
                 /*
@@ -163,17 +179,15 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
                     }
                 }
 
-                if (!possibleTestCase) {
-                    continue;
-                }
+                if (possibleTestCase) {
+                    // Add random walk at the end
+                    for (I p : getRandomChoices(alphabet, randomWalkLen, random)) {
+                        pathBuilder.append(p);
+                    }
 
-                // Add random walk at the end
-                for (I p : getRandomChoices(alphabet, randomWalkLen, random)) {
-                    pathBuilder.append(p);
+                    super.nextValue = pathBuilder.toWord();
+                    return true;
                 }
-
-                super.nextValue = pathBuilder.toWord();
-                return true;
             }
 
             return false;
@@ -193,13 +207,13 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
     }
 
     public enum CombinationMethod {
-        Combinations {
+        COMBINATIONS {
             @Override
             <S> Iterator<List<S>> getCombinations(List<S> states, int k) {
                 throw new NoSuchMethodError("TODO");
             }
         },
-        Permutations {
+        PERMUTATIONS {
             @Override
             <S> Iterator<List<S>> getCombinations(List<S> states, int k) {
                 return IterableUtil.allTuples(states, k).iterator();

--- a/util/src/main/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIterator.java
+++ b/util/src/main/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIterator.java
@@ -35,6 +35,7 @@ import net.automatalib.util.graph.Graphs;
 import net.automatalib.util.graph.apsp.APSPResult;
 import net.automatalib.word.Word;
 import net.automatalib.word.WordBuilder;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A randomized state cover test generator based on the concepts of mutation testing as described in the paper <a
@@ -43,6 +44,11 @@ import net.automatalib.word.WordBuilder;
  * <p>
  * A test case will be computed for every k-combination or k-permutation of states with additional random walk at the
  * end.
+ * <p>
+ * <b>Implementation detail:</b> Note that this test generator heavily relies on the sampling of states. If the given
+ * automaton has very few or very many states, the number of generated test cases may be very low or high, respectively.
+ * As a result, it may be advisable to {@link IteratorUtil#concat(Iterator[]) combine} this generator with other
+ * generators or limit the number of generated test cases.
  *
  * @param <S>
  *         automaton state type
@@ -54,19 +60,19 @@ import net.automatalib.word.WordBuilder;
  *         automaton type
  */
 public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>>
-        implements Iterator<Word<I>> {
+        extends AbstractSimplifiedIterator<Word<I>> {
 
     public static final int DEFAULT_R_WALK_LEN = 20;
     public static final int DEFAULT_K = 2;
 
-    private final A automaton;
     private final List<? extends I> alphabet;
     private final Random random;
     private final int randomWalkLen;
-    private final int k;
-    private final CombinationMethod method;
 
-    private final Iterator<Word<I>> iterator;
+    private final Iterator<List<S>> combIter;
+    private final Set<Set<List<TransitionEdge<I, T>>>> cache;
+    private final @Nullable S initial;
+    private final APSPResult<S, TransitionEdge<I, T>> apsp;
 
     /**
      * Convenience constructor which uses a fresh {@code random} object.
@@ -122,140 +128,80 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
                                        int randomWalkLen,
                                        int k,
                                        CombinationMethod method) {
-        this.automaton = automaton;
         this.alphabet = CollectionUtil.randomAccessList(inputs);
         this.random = random;
         this.randomWalkLen = randomWalkLen;
-        this.k = Math.min(k, automaton.size());
-        this.method = method;
 
-        final S initial = automaton.getInitialState();
+        this.cache = new HashSet<>();
+        this.apsp = Graphs.findAPSP(automaton.transitionGraphView(alphabet));
+        this.initial = automaton.getInitialState();
 
-        if (automaton.size() == 0 || initial == null) {
-            this.iterator = Collections.emptyIterator();
+        if (this.initial == null) {
+            this.combIter = Collections.emptyIterator();
         } else {
-            final FirstPhaseIterator firstIterator = new FirstPhaseIterator();
-            final SecondPhaseIterator secondPhaseIterator = new SecondPhaseIterator(initial);
-            this.iterator = IteratorUtil.concat(firstIterator, secondPhaseIterator);
+            final List<S> states = new ArrayList<>(automaton.getStates());
+            Collections.shuffle(states, random);
+            this.combIter = method.getCombinations(states, Math.min(k, automaton.size()));
         }
+
     }
 
     @Override
-    public boolean hasNext() {
-        return iterator.hasNext();
-    }
+    protected boolean calculateNext() {
 
-    @Override
-    public Word<I> next() {
-        return iterator.next();
-    }
+        while (combIter.hasNext()) {
+            final List<S> comb = combIter.next();
+            final Set<List<TransitionEdge<I, T>>> prefixes = new HashSet<>(HashUtil.capacity(comb.size()));
 
-    /**
-     * Performs random walks if the automaton only has a single state.
-     */
-    private final class FirstPhaseIterator extends AbstractSimplifiedIterator<Word<I>> {
+            List<TransitionEdge<I, T>> path = null;
+            assert initial != null;
 
-        private int idx;
+            for (S c : comb) {
+                List<TransitionEdge<I, T>> sp = apsp.getShortestPath(initial, c);
+                if (sp != null) {
+                    prefixes.add(sp);
+                    if (path == null) {
+                        path = sp;
+                    }
+                }
+            }
 
-        @Override
-        protected boolean calculateNext() {
-            if (automaton.size() == 1 && idx++ < randomWalkLen) {
-                super.nextValue = Word.fromList(RandomUtil.sample(random, alphabet, randomWalkLen));
+            if (path == null || !cache.add(prefixes)) {
+                continue;
+            }
+
+            final WordBuilder<I> pathBuilder = new WordBuilder<>();
+            for (TransitionEdge<I, T> e : path) {
+                pathBuilder.append(e.getInput());
+            }
+
+            /*
+             * in case of non-strongly connected automata test case might not be possible as a path between 2 states
+             * might not exist
+             */
+            boolean possibleTestCase = true;
+            for (int index = 0; index < comb.size() - 1; index++) {
+                final List<TransitionEdge<I, T>> pathBetweenStates =
+                        apsp.getShortestPath(comb.get(index), comb.get(index + 1));
+
+                if (pathBetweenStates == null || pathBetweenStates.isEmpty()) {
+                    possibleTestCase = false;
+                    break;
+                }
+
+                for (TransitionEdge<I, ?> t : pathBetweenStates) {
+                    pathBuilder.append(t.getInput());
+                }
+            }
+
+            if (possibleTestCase) {
+                pathBuilder.append(RandomUtil.sample(random, alphabet, randomWalkLen));
+                super.nextValue = pathBuilder.toWord();
                 return true;
             }
-            return false;
-        }
-    }
-
-    /**
-     * Performs the actual k-way coverage for automata with more than a single state.
-     */
-    private final class SecondPhaseIterator extends AbstractSimplifiedIterator<Word<I>> {
-
-        private final Iterator<List<S>> combIter;
-        private final Set<Set<List<TransitionEdge<I, T>>>> cache;
-        private final S initial;
-
-        private APSPResult<S, TransitionEdge<I, T>> apsp;
-
-        SecondPhaseIterator(S initial) {
-            this.initial = initial;
-            List<S> states = new ArrayList<>(automaton.getStates());
-            Collections.shuffle(states, random);
-            this.combIter = method.getCombinations(states, k);
-            this.cache = new HashSet<>();
         }
 
-        @Override
-        protected boolean calculateNext() {
-
-            final APSPResult<S, TransitionEdge<I, T>> apsp = getAPSP();
-
-            while (combIter.hasNext()) {
-                final List<S> comb = combIter.next();
-                final Set<List<TransitionEdge<I, T>>> prefixes = new HashSet<>(HashUtil.capacity(comb.size()));
-
-                List<TransitionEdge<I, T>> path = null;
-
-                for (S c : comb) {
-                    List<TransitionEdge<I, T>> sp = apsp.getShortestPath(initial, c);
-                    if (sp != null) {
-                        prefixes.add(sp);
-                        if (path == null) {
-                            path = sp;
-                        }
-                    }
-                }
-
-                if (path == null || !cache.add(prefixes)) {
-                    continue;
-                }
-
-                final WordBuilder<I> pathBuilder = new WordBuilder<>();
-                for (TransitionEdge<I, T> e : path) {
-                    pathBuilder.append(e.getInput());
-                }
-
-                /*
-                 * in case of non-strongly connected automata test case might not be possible as a path between 2 states
-                 * might not exist
-                 */
-                boolean possibleTestCase = true;
-                for (int index = 0; index < comb.size() - 1; index++) {
-                    final List<TransitionEdge<I, T>> pathBetweenStates =
-                            apsp.getShortestPath(comb.get(index), comb.get(index + 1));
-
-                    if (pathBetweenStates == null || pathBetweenStates.isEmpty()) {
-                        possibleTestCase = false;
-                        break;
-                    }
-
-                    for (TransitionEdge<I, ?> t : pathBetweenStates) {
-                        pathBuilder.append(t.getInput());
-                    }
-                }
-
-                if (possibleTestCase) {
-                    pathBuilder.append(RandomUtil.sample(random, alphabet, randomWalkLen));
-                    super.nextValue = pathBuilder.toWord();
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        /**
-         * Compute all-pair-shortest-paths lazily, in case this iterator is never queried.
-         *
-         * @return the all-pair-shortest-paths result
-         */
-        private APSPResult<S, TransitionEdge<I, T>> getAPSP() {
-            if (this.apsp == null) {
-                this.apsp = Graphs.findAPSP(automaton.transitionGraphView(alphabet));
-            }
-            return this.apsp;
-        }
+        return false;
     }
 
     /**

--- a/util/src/main/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIterator.java
+++ b/util/src/main/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIterator.java
@@ -1,0 +1,211 @@
+package net.automatalib.util.automaton.conformance;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import net.automatalib.automaton.UniversalDeterministicAutomaton;
+import net.automatalib.automaton.graph.TransitionEdge;
+import net.automatalib.common.util.HashUtil;
+import net.automatalib.common.util.collection.AbstractSimplifiedIterator;
+import net.automatalib.common.util.collection.CollectionUtil;
+import net.automatalib.common.util.collection.IterableUtil;
+import net.automatalib.common.util.collection.IteratorUtil;
+import net.automatalib.util.graph.Graphs;
+import net.automatalib.util.graph.apsp.APSPResult;
+import net.automatalib.word.Word;
+import net.automatalib.word.WordBuilder;
+
+public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>>
+        implements Iterator<Word<I>> {
+
+    private final A automaton;
+    private final List<? extends I> alphabet;
+    private final Random random;
+    private final int k;
+    private final int randomWalkLen;
+    private final CombinationMethod method;
+
+    private final Iterator<Word<I>> iterator;
+
+    public KWayStateCoverTestsIterator(A automaton, Collection<? extends I> inputs) {
+        this(automaton, inputs, new Random());
+    }
+
+    public KWayStateCoverTestsIterator(A automaton, Collection<? extends I> inputs, Random random) {
+        this(automaton, inputs, random, 2, 20, CombinationMethod.Permutations);
+    }
+
+    public KWayStateCoverTestsIterator(A automaton,
+                                       Collection<? extends I> inputs,
+                                       Random random,
+                                       int k,
+                                       int randomWalkLen,
+                                       CombinationMethod method) {
+        this.automaton = automaton;
+        this.alphabet = CollectionUtil.randomAccessList(inputs);
+        this.k = k;
+        this.randomWalkLen = randomWalkLen;
+        this.method = method;
+        this.random = random;
+
+        if (automaton.size() == 0) {
+            this.iterator = Collections.emptyIterator();
+        } else {
+            final FirstPhaseIterator firstIterator = new FirstPhaseIterator();
+            final SecondPhaseIterator secondPhaseIterator = new SecondPhaseIterator();
+            this.iterator = IteratorUtil.concat(firstIterator, secondPhaseIterator);
+        }
+    }
+
+    @Override
+    public boolean hasNext() {
+        return iterator.hasNext();
+    }
+
+    @Override
+    public Word<I> next() {
+        return iterator.next();
+    }
+
+    static <I> Word<I> getRandomChoices(List<? extends I> alphabet, int count, Random random) {
+        WordBuilder<I> choices = new WordBuilder<>(count);
+
+        for (int i = 0; i < count; i++) {
+            choices.add(alphabet.get(random.nextInt(alphabet.size())));
+        }
+
+        return choices.toWord();
+    }
+
+    /**
+     * Performs random walks if the automaton only has a single state.
+     */
+    private final class FirstPhaseIterator extends AbstractSimplifiedIterator<Word<I>> {
+
+        private int idx = 0;
+
+        @Override
+        protected boolean calculateNext() {
+            if (automaton.size() == 1) {
+                if (idx++ < randomWalkLen) {
+                    super.nextValue = getRandomChoices(alphabet, randomWalkLen, random);
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Performs the actual k-way coverage for automata with more than a single state.
+     */
+    private final class SecondPhaseIterator extends AbstractSimplifiedIterator<Word<I>> {
+
+        private final Iterator<List<S>> combIter;
+        private final Set<Set<List<TransitionEdge<I, T>>>> cache;
+
+        private APSPResult<S, TransitionEdge<I, T>> apsp;
+
+        public SecondPhaseIterator() {
+            List<S> states = new ArrayList<>(automaton.getStates());
+            Collections.shuffle(states, random);
+            this.combIter = method.getCombinations(states, k);
+            this.cache = new HashSet<>();
+        }
+
+        @Override
+        protected boolean calculateNext() {
+
+            final S initial = automaton.getInitialState();
+            final APSPResult<S, TransitionEdge<I, T>> apsp = getAPSP();
+
+            while (combIter.hasNext()) {
+                final List<S> comb = combIter.next();
+                final Set<List<TransitionEdge<I, T>>> prefixes = new HashSet<>(HashUtil.capacity(comb.size()));
+
+                for (S c : comb) {
+                    prefixes.add(apsp.getShortestPath(initial, c));
+                }
+
+                if (!cache.add(prefixes)) {
+                    continue;
+                }
+
+                final List<TransitionEdge<I, T>> firstPath = apsp.getShortestPath(initial, comb.get(0));
+                assert firstPath != null;
+
+                final WordBuilder<I> pathBuilder = new WordBuilder<>();
+                for (TransitionEdge<I, T> e : firstPath) {
+                    pathBuilder.add(e.getInput());
+                }
+
+                /*
+                 * in case of non-strongly connected automata test case might not be possible as a path between 2 states
+                 * might not exist
+                 */
+                boolean possibleTestCase = true;
+                for (int index = 0; index < comb.size() - 1; index++) {
+                    final List<? extends TransitionEdge<I, ?>> pathBetweenStates =
+                            apsp.getShortestPath(comb.get(index), comb.get(index + 1));
+
+                    if (pathBetweenStates == null || pathBetweenStates.isEmpty()) {
+                        possibleTestCase = false;
+                        break;
+                    }
+
+                    for (TransitionEdge<I, ?> pathBetweenState : pathBetweenStates) {
+                        pathBuilder.append(pathBetweenState.getInput());
+                    }
+                }
+
+                if (!possibleTestCase) {
+                    continue;
+                }
+
+                // Add random walk at the end
+                for (I p : getRandomChoices(alphabet, randomWalkLen, random)) {
+                    pathBuilder.append(p);
+                }
+
+                super.nextValue = pathBuilder.toWord();
+                return true;
+            }
+
+            return false;
+        }
+
+        /**
+         * Compute all-pair-shortest-paths lazily, in case this iterator is never queried.
+         *
+         * @return the all-pair-shortest-paths result
+         */
+        private APSPResult<S, TransitionEdge<I, T>> getAPSP() {
+            if (this.apsp == null) {
+                this.apsp = Graphs.findAPSP(automaton.transitionGraphView(alphabet));
+            }
+            return this.apsp;
+        }
+    }
+
+    public enum CombinationMethod {
+        Combinations {
+            @Override
+            <S> Iterator<List<S>> getCombinations(List<S> states, int k) {
+                throw new NoSuchMethodError("TODO");
+            }
+        },
+        Permutations {
+            @Override
+            <S> Iterator<List<S>> getCombinations(List<S> states, int k) {
+                return IterableUtil.allTuples(states, k).iterator();
+            }
+        };
+
+        abstract <S> Iterator<List<S>> getCombinations(List<S> states, int k);
+    }
+}

--- a/util/src/main/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIterator.java
+++ b/util/src/main/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIterator.java
@@ -35,6 +35,7 @@ import net.automatalib.util.graph.Graphs;
 import net.automatalib.util.graph.apsp.APSPResult;
 import net.automatalib.word.Word;
 import net.automatalib.word.WordBuilder;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A randomized state cover test generator based on the concepts of mutation testing as described in the paper <a
@@ -173,7 +174,7 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
     private final class SecondPhaseIterator extends AbstractSimplifiedIterator<Word<I>> {
 
         private final Iterator<List<S>> combIter;
-        private final Set<Set<List<TransitionEdge<I, T>>>> cache;
+        private final Set<Set<@Nullable List<TransitionEdge<I, T>>>> cache;
         private final S initial;
 
         private APSPResult<S, TransitionEdge<I, T>> apsp;
@@ -193,7 +194,8 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
 
             while (combIter.hasNext()) {
                 final List<S> comb = combIter.next();
-                final Set<List<TransitionEdge<I, T>>> prefixes = new HashSet<>(HashUtil.capacity(comb.size()));
+                final Set<@Nullable List<TransitionEdge<I, T>>> prefixes =
+                        new HashSet<>(HashUtil.capacity(comb.size()));
 
                 for (S c : comb) {
                     prefixes.add(apsp.getShortestPath(initial, c));
@@ -225,8 +227,8 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
                         break;
                     }
 
-                    for (TransitionEdge<I, ?> pathBetweenState : pathBetweenStates) {
-                        pathBuilder.append(pathBetweenState.getInput());
+                    for (TransitionEdge<I, ?> t : pathBetweenStates) {
+                        pathBuilder.append(t.getInput());
                     }
                 }
 

--- a/util/src/main/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIterator.java
+++ b/util/src/main/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIterator.java
@@ -35,7 +35,6 @@ import net.automatalib.util.graph.Graphs;
 import net.automatalib.util.graph.apsp.APSPResult;
 import net.automatalib.word.Word;
 import net.automatalib.word.WordBuilder;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A randomized state cover test generator based on the concepts of mutation testing as described in the paper <a
@@ -174,7 +173,7 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
     private final class SecondPhaseIterator extends AbstractSimplifiedIterator<Word<I>> {
 
         private final Iterator<List<S>> combIter;
-        private final Set<Set<@Nullable List<TransitionEdge<I, T>>>> cache;
+        private final Set<Set<List<TransitionEdge<I, T>>>> cache;
         private final S initial;
 
         private APSPResult<S, TransitionEdge<I, T>> apsp;
@@ -194,22 +193,26 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
 
             while (combIter.hasNext()) {
                 final List<S> comb = combIter.next();
-                final Set<@Nullable List<TransitionEdge<I, T>>> prefixes =
-                        new HashSet<>(HashUtil.capacity(comb.size()));
+                final Set<List<TransitionEdge<I, T>>> prefixes = new HashSet<>(HashUtil.capacity(comb.size()));
+
+                List<TransitionEdge<I, T>> path = null;
 
                 for (S c : comb) {
-                    prefixes.add(apsp.getShortestPath(initial, c));
+                    List<TransitionEdge<I, T>> sp = apsp.getShortestPath(initial, c);
+                    if (sp != null) {
+                        prefixes.add(sp);
+                        if (path == null) {
+                            path = sp;
+                        }
+                    }
                 }
 
-                if (!cache.add(prefixes)) {
+                if (path == null || !cache.add(prefixes)) {
                     continue;
                 }
 
-                final List<TransitionEdge<I, T>> firstPath = apsp.getShortestPath(initial, comb.get(0));
-                assert firstPath != null;
-
                 final WordBuilder<I> pathBuilder = new WordBuilder<>();
-                for (TransitionEdge<I, T> e : firstPath) {
+                for (TransitionEdge<I, T> e : path) {
                     pathBuilder.append(e.getInput());
                 }
 

--- a/util/src/main/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIterator.java
+++ b/util/src/main/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIterator.java
@@ -18,21 +18,24 @@ package net.automatalib.util.automaton.conformance;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.stream.Stream;
 
-import net.automatalib.automaton.UniversalDeterministicAutomaton;
-import net.automatalib.automaton.graph.TransitionEdge;
+import net.automatalib.automaton.DeterministicAutomaton;
 import net.automatalib.common.util.HashUtil;
 import net.automatalib.common.util.collection.AbstractSimplifiedIterator;
 import net.automatalib.common.util.collection.CollectionUtil;
 import net.automatalib.common.util.collection.IteratorUtil;
+import net.automatalib.common.util.mapping.Mapping;
+import net.automatalib.common.util.mapping.Mappings;
 import net.automatalib.common.util.random.RandomUtil;
-import net.automatalib.util.graph.Graphs;
-import net.automatalib.util.graph.apsp.APSPResult;
+import net.automatalib.util.automaton.cover.Covers;
 import net.automatalib.word.Word;
 import net.automatalib.word.WordBuilder;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -48,31 +51,37 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * <b>Implementation detail:</b> Note that this test generator heavily relies on the sampling of states. If the given
  * automaton has very few or very many states, the number of generated test cases may be very low or high, respectively.
  * As a result, it may be advisable to {@link IteratorUtil#concat(Iterator[]) combine} this generator with other
- * generators or limit the number of generated test cases.
+ * generators or {@link Stream#limit(long) limit} the number of generated test cases.
  *
  * @param <S>
  *         automaton state type
  * @param <I>
  *         input symbol type
- * @param <T>
- *         transition type
  * @param <A>
  *         automaton type
  */
-public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>>
+public class KWayStateCoverTestsIterator<S, I, A extends DeterministicAutomaton<S, I, ?>>
         extends AbstractSimplifiedIterator<Word<I>> {
 
-    public static final int DEFAULT_R_WALK_LEN = 20;
+    /**
+     * The default value of k used in the k-way combinations/permutations.
+     */
     public static final int DEFAULT_K = 2;
 
+    /**
+     * The default length of random walks performed at the end of each combination/permutation.
+     */
+    public static final int DEFAULT_R_WALK_LEN = 20;
+
+    private final A automaton;
     private final List<? extends I> alphabet;
     private final Random random;
     private final int randomWalkLen;
 
     private final Iterator<List<S>> combIter;
-    private final Set<Set<List<TransitionEdge<I, T>>>> cache;
+    private final Set<Set<Word<I>>> cache;
     private final @Nullable S initial;
-    private final APSPResult<S, TransitionEdge<I, T>> apsp;
+    private final Map<S, Mapping<S, @Nullable Word<I>>> apsp;
 
     /**
      * Convenience constructor which uses a fresh {@code random} object.
@@ -82,15 +91,16 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
      * @param inputs
      *         the inputs to consider for test case generation
      *
-     * @see #KWayStateCoverTestsIterator(UniversalDeterministicAutomaton, Collection, Random)
+     * @see #KWayStateCoverTestsIterator(DeterministicAutomaton, Collection, Random)
      */
     public KWayStateCoverTestsIterator(A automaton, Collection<? extends I> inputs) {
         this(automaton, inputs, new Random());
     }
 
     /**
-     * Convenience constructor. Uses {@code k=2}, {@code randomWalkLen = 20}, and
-     * {@code method = CombinationMethod.PERMUTATIONS}.
+     * Convenience constructor. Uses <code>k = {@value #DEFAULT_K}</code>, <code>randomWalkLen =
+     * {@value #DEFAULT_R_WALK_LEN}</code>, and
+     * <code>method = {@link CombinationMethod#PERMUTATIONS}</code>.
      *
      * @param automaton
      *         the automaton for which to generate test cases
@@ -99,8 +109,7 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
      * @param random
      *         the random number generator to use
      *
-     * @see #KWayStateCoverTestsIterator(UniversalDeterministicAutomaton, Collection, Random, int, int,
-     * CombinationMethod)
+     * @see #KWayStateCoverTestsIterator(DeterministicAutomaton, Collection, Random, int, int, CombinationMethod)
      */
     public KWayStateCoverTestsIterator(A automaton, Collection<? extends I> inputs, Random random) {
         this(automaton, inputs, random, DEFAULT_R_WALK_LEN, DEFAULT_K, CombinationMethod.PERMUTATIONS);
@@ -116,9 +125,9 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
      * @param random
      *         the random number generator to use
      * @param randomWalkLen
-     *         length of random walk performed at the end of each combination/permutation
+     *         length of random walks performed at the end of each combination/permutation
      * @param k
-     *         k value used for k-wise combinations/permutations of states
+     *         k value used for k-way combinations/permutations of states
      * @param method
      *         the method for computing combinations
      */
@@ -128,20 +137,23 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
                                        int randomWalkLen,
                                        int k,
                                        CombinationMethod method) {
+        this.automaton = automaton;
         this.alphabet = CollectionUtil.randomAccessList(inputs);
         this.random = random;
         this.randomWalkLen = randomWalkLen;
 
         this.cache = new HashSet<>();
-        this.apsp = Graphs.findAPSP(automaton.transitionGraphView(alphabet));
         this.initial = automaton.getInitialState();
 
         if (this.initial == null) {
             this.combIter = Collections.emptyIterator();
+            this.apsp = Collections.emptyMap();
         } else {
             final List<S> states = new ArrayList<>(automaton.getStates());
             Collections.shuffle(states, random);
             this.combIter = method.getCombinations(states, Math.min(k, automaton.size()));
+            this.apsp = new HashMap<>(HashUtil.capacity(automaton.size()));
+            this.apsp.put(this.initial, Covers.cover(automaton, inputs, this.initial, w -> {}, w -> {}));
         }
 
     }
@@ -151,13 +163,13 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
 
         while (combIter.hasNext()) {
             final List<S> comb = combIter.next();
-            final Set<List<TransitionEdge<I, T>>> prefixes = new HashSet<>(HashUtil.capacity(comb.size()));
+            final Set<Word<I>> prefixes = new HashSet<>(HashUtil.capacity(comb.size()));
 
-            List<TransitionEdge<I, T>> path = null;
+            Word<I> path = null;
             assert initial != null;
 
             for (S c : comb) {
-                List<TransitionEdge<I, T>> sp = apsp.getShortestPath(initial, c);
+                Word<I> sp = apsp.getOrDefault(initial, Mappings.nullMapping()).get(c);
                 if (sp != null) {
                     prefixes.add(sp);
                     if (path == null) {
@@ -170,10 +182,7 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
                 continue;
             }
 
-            final WordBuilder<I> pathBuilder = new WordBuilder<>();
-            for (TransitionEdge<I, T> e : path) {
-                pathBuilder.append(e.getInput());
-            }
+            final WordBuilder<I> pathBuilder = new WordBuilder<>(path);
 
             /*
              * in case of non-strongly connected automata test case might not be possible as a path between 2 states
@@ -181,17 +190,20 @@ public class KWayStateCoverTestsIterator<S, I, T, A extends UniversalDeterminist
              */
             boolean possibleTestCase = true;
             for (int index = 0; index < comb.size() - 1; index++) {
-                final List<TransitionEdge<I, T>> pathBetweenStates =
-                        apsp.getShortestPath(comb.get(index), comb.get(index + 1));
+                final Word<I> pathBetweenStates = apsp.computeIfAbsent(comb.get(index),
+                                                                       k -> Covers.cover(automaton,
+                                                                                         alphabet,
+                                                                                         k,
+                                                                                         w -> {},
+                                                                                         w -> {}))
+                                                      .get(comb.get(index + 1));
 
                 if (pathBetweenStates == null || pathBetweenStates.isEmpty()) {
                     possibleTestCase = false;
                     break;
                 }
 
-                for (TransitionEdge<I, ?> t : pathBetweenStates) {
-                    pathBuilder.append(t.getInput());
-                }
+                pathBuilder.append(pathBetweenStates);
             }
 
             if (possibleTestCase) {

--- a/util/src/main/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIterator.java
+++ b/util/src/main/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIterator.java
@@ -1,3 +1,18 @@
+/* Copyright (C) 2013-2025 TU Dortmund University
+ * This file is part of AutomataLib <https://automatalib.net>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.automatalib.util.automaton.conformance;
 
 import java.util.ArrayList;
@@ -11,6 +26,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
+
 import net.automatalib.automaton.UniversalDeterministicAutomaton;
 import net.automatalib.automaton.graph.TransitionEdge;
 import net.automatalib.common.util.HashUtil;
@@ -25,6 +41,12 @@ import net.automatalib.word.WordBuilder;
 
 public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>>
         implements Iterator<Word<I>> {
+
+    private static final int DEFAULT_K = 2;
+    private static final int DEFAULT_NUM_GENERATED_PATHS = 1_000;
+    private static final int DEFAULT_MAX_PATH_LENGTH = 50;
+    private static final int DEFAULT_MAX_NUMBER_OF_STEPS = 0;
+    private static final int DEFAULT_RANDOM_WALK_LENGTH = 10;
 
     private final A automaton;
     private final List<? extends I> alphabet;
@@ -46,7 +68,16 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
     }
 
     public KWayTransitionCoverTestsIterator(A automaton, Collection<? extends I> inputs, Random random) {
-        this(automaton, inputs, random, 2, Method.Random, 1000, 50, 0, Optimize.Steps, 10);
+        this(automaton,
+             inputs,
+             random,
+             DEFAULT_K,
+             Method.RANDOM,
+             DEFAULT_NUM_GENERATED_PATHS,
+             DEFAULT_MAX_PATH_LENGTH,
+             DEFAULT_MAX_NUMBER_OF_STEPS,
+             Optimize.STEPS,
+             DEFAULT_RANDOM_WALK_LENGTH);
     }
 
     public KWayTransitionCoverTestsIterator(A automaton,
@@ -71,14 +102,14 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
         this.randomWalkLen = randomWalkLen;
 
         switch (method) {
-            case Prefix:
-                this.iterator = generatePrefixSteps(automaton).iterator();
+            case PREFIX:
+                this.iterator = generatePrefixSteps(automaton);
                 break;
-            case Random:
+            case RANDOM:
                 this.iterator = new GreedySetCoverIterator();
                 break;
             default:
-                throw new IllegalArgumentException("Unknown method " + method);
+                this.iterator = Collections.emptyIterator();
         }
     }
 
@@ -105,10 +136,6 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
         return result;
     }
 
-    /**
-     * * Creates Path object from provided automaton steps within specified Hypothesis context.** * *@return Newly
-     * created Path instance corresponding to provided step sequence.**
-     **/
     private Path<S, I> createPath(A hypothesis, Word<I> steps) {
         Set<KWayTransition<S, I>> transitions = new HashSet<>();
         List<KWayTransition<S, I>> transitionsLog = new ArrayList<>();
@@ -142,53 +169,56 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
                           transitionsLog);
     }
 
-    public Iterable<Word<I>> generatePrefixSteps(A hypothesis) {
+    private Iterator<Word<I>> generatePrefixSteps(A hypothesis) {
         List<S> states = new ArrayList<>(hypothesis.getStates());
         Collections.reverse(states);
-        return () -> new PrefixStepsIterator(states.iterator());
+        return new PrefixStepsIterator(states.iterator());
     }
 
-    /**
-     * Selects an optimal path from available candidates based on optimization strategy defined.
-     *
-     * @return Selected Path object or null if no suitable path is found.
-     **/
     private Path<S, I> selectOptimalPath(Set<KWayTransition<S, I>> covered, Collection<Path<S, I>> paths) {
         Path<S, I> max = Collections.max(paths, optimize.getPathComparator(covered));
-        return max.kWayTransitions.size() != covered.size() ? max : null;
-    }
-
-    private static <I> List<I> getRandomChoices(List<? extends I> alphabet, int count, Random random) {
-        List<I> choices = new ArrayList<>(count);
-
-        for (int i = 0; i < count; i++) {
-            choices.add(alphabet.get(random.nextInt(alphabet.size())));
-        }
-
-        return choices;
+        // require max to provide new transitions
+        return covered.containsAll(max.kWayTransitions) ? null : max;
     }
 
     public enum Method {
-        Random,
-        Prefix
+        RANDOM,
+        PREFIX
     }
 
     public enum Optimize {
-        Steps {
+        STEPS {
             @Override
             <S, I> Comparator<Path<S, I>> getPathComparator(Set<KWayTransition<S, I>> covered) {
-                return Comparator.comparingDouble(p -> ((double) (p.kWayTransitions.size() - covered.size())) /
+                return Comparator.comparingDouble(p -> ((double) computeSizeOfDiff(p.kWayTransitions, covered)) /
                                                        p.steps.size());
             }
         },
-        Queries {
+        QUERIES {
             @Override
             <S, I> Comparator<Path<S, I>> getPathComparator(Set<KWayTransition<S, I>> covered) {
-                return Comparator.comparingDouble(p -> (p.kWayTransitions.size() - covered.size()));
+                return Comparator.comparingDouble(p -> computeSizeOfDiff(p.kWayTransitions, covered));
             }
         };
 
         abstract <S, I> Comparator<Path<S, I>> getPathComparator(Set<KWayTransition<S, I>> covered);
+
+        /**
+         * Computes the size of the set difference without actually materializing the difference.
+         *
+         * @return size of the difference
+         */
+        private static <S, I> int computeSizeOfDiff(Set<KWayTransition<S, I>> transitions,
+                                                    Set<KWayTransition<S, I>> covered) {
+            int size = transitions.size();
+            for (KWayTransition<S, I> t : covered) {
+                if (transitions.contains(t)) {
+                    size--;
+                }
+            }
+
+            return size;
+        }
     }
 
     private class GreedySetCoverIterator extends AbstractSimplifiedIterator<Word<I>> {
@@ -199,7 +229,7 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
 
         private int stepCount;
 
-        public GreedySetCoverIterator() {
+        GreedySetCoverIterator() {
             this.paths = generateRandomPaths(automaton);
             this.paths.addAll(cachedPaths);
             this.covered = new HashSet<>();
@@ -216,13 +246,15 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
                     covered.addAll(path.kWayTransitions);
                     paths.remove(path);
                     stepCount += path.steps.size();
-//                    result.add(path);
+                    //result.add(path);
                     super.nextValue = path.steps;
                     return true;
                 }
 
                 if (paths.isEmpty()) {
-                    for (Word<I> generatePrefixStep : generatePrefixSteps(automaton)) {
+                    Iterator<Word<I>> prefixIterator = generatePrefixSteps(automaton);
+                    while (prefixIterator.hasNext()) {
+                        Word<I> generatePrefixStep = prefixIterator.next();
                         paths.add(createPath(automaton, generatePrefixStep));
                     }
                 }
@@ -240,7 +272,7 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
         private final APSPResult<S, TransitionEdge<I, T>> apsp;
         private final S initial;
 
-        public PrefixStepsIterator(Iterator<S> listIterator) {
+        PrefixStepsIterator(Iterator<S> listIterator) {
             super(listIterator);
             this.apsp = Graphs.findAPSP(automaton.transitionGraphView(alphabet));
             this.initial = automaton.getInitialState();
@@ -264,8 +296,8 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
                 wb.append(edge.getInput());
             }
 
-            wb.addAll(steps);
-            wb.addAll(getRandomChoices(alphabet, randomWalkLen, random));
+            wb.append(steps);
+            wb.append(KWayStateCoverTestsIterator.getRandomChoices(alphabet, randomWalkLen, random));
 
             return wb.toWord();
         }
@@ -277,7 +309,7 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
         private final S endState;
         private final Word<I> steps;
 
-        private KWayTransition(S startState, S endState, Word<I> steps) {
+        KWayTransition(S startState, S endState, Word<I> steps) {
             this.startState = startState;
             this.endState = endState;
             this.steps = steps;
@@ -311,11 +343,11 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
         private final Set<KWayTransition<S, I>> kWayTransitions;
         private final List<KWayTransition<S, I>> transitionsLog;
 
-        private Path(S startState,
-                     S endState,
-                     Word<I> steps,
-                     Set<KWayTransition<S, I>> kWayTransitions,
-                     List<KWayTransition<S, I>> transitionsLog) {
+        Path(S startState,
+             S endState,
+             Word<I> steps,
+             Set<KWayTransition<S, I>> kWayTransitions,
+             List<KWayTransition<S, I>> transitionsLog) {
             this.startState = startState;
             this.endState = endState;
             this.steps = steps;

--- a/util/src/main/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIterator.java
+++ b/util/src/main/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIterator.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
@@ -39,13 +38,14 @@ import net.automatalib.util.graph.Graphs;
 import net.automatalib.util.graph.apsp.APSPResult;
 import net.automatalib.word.Word;
 import net.automatalib.word.WordBuilder;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * A randomized state cover test generator based on the concepts of mutation testing as described in the paper <a
+ * A randomized transition cover test generator based on the concepts of mutation testing as described in the paper <a
  * href="https://doi.org/10.1007/978-3-319-57288-8_2">Learning from Faults: Mutation Testing in Active Automata
  * Learning</a> by Bernhard K. Aichernig and Martin Tappler.
  * <p>
- * This iterates selects test cases based on k-way transitions coverage. It does that by generating random test words
+ * This iterator selects test cases based on k-way transitions coverage. It does that by generating random test words
  * and finding the smallest subset with the highest coverage. In other words, this iterator generates test words by
  * running random paths that cover all pairwise / k-way transitions.
  *
@@ -131,20 +131,20 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
      * @param random
      *         the random number generator to use
      * @param randomWalkLen
-     *         the number of steps that are added by 'prefix' generated paths
+     *         the number of steps that are added by {@link GenerationMethod#PREFIX prefix}-generated paths
      * @param numGeneratePaths
-     *         number of random queries used to find the optimal subset
+     *         number of {@link GenerationMethod#RANDOM randomly}-generated queries used to find the optimal subset
      * @param maxPathLen
-     *         the maximum step size of a generated path
+     *         the maximum step size of {@link GenerationMethod#RANDOM randomly}-generated paths
      * @param maxNumberOfSteps
-     *         maximum number of steps that will be executed on the automaton (<=0 = no limit)
+     *         threshold for the number of steps after which no more new test words will be generated (<=0 = no limit)
      * @param k
-     *         k value used for K-Way transitions, i.e the number of steps between the start and the end of a
+     *         k value used for K-Way transitions, i.e.,the number of steps between the start and the end of a
      *         transition
      * @param generationMethod
-     *         defines how the queries are generated 'random' or 'prefix'
+     *         defines how the queries are generated
      * @param optimizationMetric
-     *         minimize either the number of 'steps' or 'queries' that are executed
+     *         the metric after which test cases are minimized
      */
     public KWayTransitionCoverTestsIterator(A automaton,
                                             Collection<? extends I> inputs,
@@ -172,7 +172,7 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
         if (automaton.size() == 0 || initial == null) {
             this.iterator = Collections.emptyIterator();
         } else {
-            this.iterator = generationMethod.getIterator(this);
+            this.iterator = generationMethod.getIterator(this, initial);
         }
     }
 
@@ -186,128 +186,156 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
         return iterator.next();
     }
 
-    private Set<Path<S, I>> generateRandomPaths(A hypothesis) {
-        Set<Path<S, I>> result = new LinkedHashSet<>(HashUtil.capacity(numGeneratePaths));
+    private Set<Path<S, I>> generateRandomPaths(A hypothesis, S initial) {
+        final Set<Path<S, I>> result = new HashSet<>(HashUtil.capacity(numGeneratePaths));
 
         for (int i = 0; i < numGeneratePaths; i++) {
-            int randomLength = random.nextInt(maxPathLen - k + 1) + k; // Ensuring length is at least `k`
-            Word<I> steps = Word.fromList(RandomUtil.sample(random, alphabet, randomLength));
-            Path<S, I> path = createPath(hypothesis, steps);
+            final int randomLength = random.nextInt(maxPathLen - k + 1) + k; // Ensuring length is at least `k`
+            final Word<I> steps = Word.fromList(RandomUtil.sample(random, alphabet, randomLength));
+            final Path<S, I> path = createPath(hypothesis, initial, steps);
             result.add(path);
         }
 
         return result;
     }
 
-    private Path<S, I> createPath(A hypothesis, Word<I> steps) {
-        Set<KWayTransition<S, I>> transitions = new HashSet<>();
-        List<KWayTransition<S, I>> transitionsLog = new ArrayList<>();
+    private Path<S, I> createPath(A hypothesis, S initial, Word<I> steps) {
+        final Set<KWayTransition<S, I>> transitions = new HashSet<>();
 
-        List<S> prevStates = new ArrayList<>(steps.size());
-        List<S> endStates = new ArrayList<>(steps.size());
+        final List<S> prevStates = new ArrayList<>(steps.size());
+        final List<S> endStates = new ArrayList<>(steps.size());
 
-        S iter = hypothesis.getInitialState();
+        S iter = initial;
+        Word<I> reachableSteps = steps;
 
-        for (I i : steps) {
-            prevStates.add(iter);
-            iter = hypothesis.getSuccessor(iter, i);
-            endStates.add(iter);
+        for (int i = 0; i < steps.length(); i++) {
+            final S succ = hypothesis.getSuccessor(iter, steps.getSymbol(i));
+            if (succ == null) {
+                reachableSteps = steps.subWord(0, i);
+            } else {
+                prevStates.add(iter);
+                endStates.add(succ);
+                iter = succ;
+            }
         }
 
-        for (int i = 0; i < steps.size() - k + 1; i++) {
-            S prevState = prevStates.get(i);
-            S endState = endStates.get(i + k - 1);
-            Word<I> chunk = steps.subWord(i, i + k);
+        for (int i = 0; i < reachableSteps.size() - k + 1; i++) {
+            final S prevState = prevStates.get(i);
+            final S endState = endStates.get(i + k - 1);
+            final Word<I> chunk = steps.subWord(i, i + k);
 
-            KWayTransition<S, I> transition = new KWayTransition<>(prevState, endState, chunk);
+            final KWayTransition<S, I> transition = new KWayTransition<>(prevState, endState, chunk);
 
-            transitionsLog.add(transition);
             transitions.add(transition);
         }
 
-        return new Path<>(hypothesis.getInitialState(),
-                          endStates.get(endStates.size() - 1),
-                          steps,
-                          transitions,
-                          transitionsLog);
+        return new Path<>(steps, transitions);
     }
 
-    private Iterator<Word<I>> generatePrefixSteps(A hypothesis) {
-        List<S> states = new ArrayList<>(hypothesis.getStates());
+    private Iterator<Word<I>> generatePrefixSteps(A hypothesis, S initial) {
+        final List<S> states = new ArrayList<>(hypothesis.getStates());
         Collections.reverse(states);
-        return new PrefixStepsIterator(states.iterator());
+        return new PrefixStepsIterator(states.iterator(), initial);
     }
 
-    private Path<S, I> selectOptimalPath(Set<KWayTransition<S, I>> covered, Collection<Path<S, I>> paths) {
-        Path<S, I> max = Collections.max(paths, optimizationMetric.getPathComparator(covered));
-        return max.kWayTransitions.size() == covered.size() ? null : max;
+    private @Nullable Path<S, I> selectOptimalPath(Set<KWayTransition<S, I>> covered, Set<Path<S, I>> paths) {
+        final Path<S, I> max = Collections.max(paths, optimizationMetric.getPathComparator(covered));
+        return sizeOfSetDifference(max.kWayTransitions, covered) > 0 ? max : null;
     }
 
+    static <T> int sizeOfSetDifference(Set<T> minuend, Set<T> subtrahend) {
+        /*
+         * This method is performance-critical so we do a little bit more involved computation.
+         */
+        final Set<T> smaller, bigger;
+        if (minuend.size() < subtrahend.size()) {
+            smaller = minuend;
+            bigger = subtrahend;
+        } else {
+            smaller = subtrahend;
+            bigger = minuend;
+        }
+
+        int size = minuend.size();
+        for (T t : smaller) {
+            if (bigger.contains(t)) {
+                size--;
+            }
+        }
+        return size;
+    }
+
+    /**
+     * Method by which the prefixes of test words should be generated.
+     */
     public enum GenerationMethod {
+        /**
+         * Generate prefixes randomly.
+         */
         RANDOM {
             @Override
             <S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>> Iterator<Word<I>> getIterator(
-                    KWayTransitionCoverTestsIterator<S, I, T, A> self) {
-                return self.new GreedySetCoverIterator();
+                    KWayTransitionCoverTestsIterator<S, I, T, A> self,
+                    S initial) {
+                return self.new GreedySetCoverIterator(initial);
             }
         },
+        /**
+         * Generate prefixes based on access sequences.
+         */
         PREFIX {
             @Override
             <S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>> Iterator<Word<I>> getIterator(
-                    KWayTransitionCoverTestsIterator<S, I, T, A> self) {
-                return self.generatePrefixSteps(self.automaton);
+                    KWayTransitionCoverTestsIterator<S, I, T, A> self,
+                    S initial) {
+                return self.generatePrefixSteps(self.automaton, initial);
             }
         };
 
         abstract <S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>> Iterator<Word<I>> getIterator(
-                KWayTransitionCoverTestsIterator<S, I, T, A> self);
+                KWayTransitionCoverTestsIterator<S, I, T, A> self,
+                S initial);
     }
 
+    /**
+     * The metric by which to optimize path selection.
+     */
     public enum OptimizationMetric {
+        /**
+         * Selects the paths maximum coverage per step, thus reducing the number of total steps.
+         */
         STEPS {
             @Override
             <S, I> Comparator<Path<S, I>> getPathComparator(Set<KWayTransition<S, I>> covered) {
-                return Comparator.comparingDouble(p -> ((double) computeSizeOfDiff(p.kWayTransitions, covered)) /
+                return Comparator.comparingDouble(p -> ((double) sizeOfSetDifference(p.kWayTransitions, covered)) /
                                                        p.steps.size());
             }
         },
+        /**
+         * Selects the paths with maximum coverage, thus reducing number of test words.
+         */
         QUERIES {
             @Override
             <S, I> Comparator<Path<S, I>> getPathComparator(Set<KWayTransition<S, I>> covered) {
-                return Comparator.comparingDouble(p -> p.kWayTransitions.size() - covered.size());
+                return Comparator.comparingDouble(p -> sizeOfSetDifference(p.kWayTransitions, covered));
             }
         };
 
         abstract <S, I> Comparator<Path<S, I>> getPathComparator(Set<KWayTransition<S, I>> covered);
-
-        /**
-         * Computes the size of the set difference without actually materializing the difference.
-         *
-         * @return size of the difference
-         */
-        private static <S, I> int computeSizeOfDiff(Set<KWayTransition<S, I>> transitions,
-                                                    Set<KWayTransition<S, I>> covered) {
-            int size = transitions.size();
-            for (KWayTransition<S, I> t : covered) {
-                if (transitions.contains(t)) {
-                    size--;
-                }
-            }
-
-            return size;
-        }
     }
 
     private class GreedySetCoverIterator extends AbstractSimplifiedIterator<Word<I>> {
 
+        private final S initial;
         private final Set<Path<S, I>> paths;
-        private final int sizeOfUniverse;
         private final Set<KWayTransition<S, I>> covered;
+        private final int sizeOfUniverse;
 
         private int stepCount;
 
-        GreedySetCoverIterator() {
-            this.paths = generateRandomPaths(automaton);
+        GreedySetCoverIterator(S initial) {
+            this.initial = initial;
+            this.paths = generateRandomPaths(automaton, initial);
             this.covered = new HashSet<>();
             this.stepCount = 0;
             this.sizeOfUniverse = automaton.getStates().size() * (int) Math.pow(alphabet.size(), k);
@@ -315,8 +343,8 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
 
         @Override
         protected boolean calculateNext() {
-            if (sizeOfUniverse > covered.size()) {
-                Path<S, I> path = selectOptimalPath(covered, paths);
+            while (sizeOfUniverse > covered.size()) {
+                final Path<S, I> path = selectOptimalPath(covered, paths);
 
                 if (path != null) {
                     covered.addAll(path.kWayTransitions);
@@ -327,11 +355,14 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
                 }
 
                 if (paths.isEmpty()) {
-                    Iterator<Word<I>> prefixIterator = generatePrefixSteps(automaton);
+                    final Iterator<Word<I>> prefixIterator = generatePrefixSteps(automaton, initial);
                     while (prefixIterator.hasNext()) {
-                        Word<I> generatePrefixStep = prefixIterator.next();
-                        paths.add(createPath(automaton, generatePrefixStep));
+                        final Word<I> generatePrefixStep = prefixIterator.next();
+                        paths.add(createPath(automaton, initial, generatePrefixStep));
                     }
+                } else {
+                    // prevent infinite loops
+                    return false;
                 }
 
                 if (maxNumberOfSteps != 0 && stepCount > maxNumberOfSteps) {
@@ -347,21 +378,27 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
         private final APSPResult<S, TransitionEdge<I, T>> apsp;
         private final S initial;
 
-        PrefixStepsIterator(Iterator<S> listIterator) {
-            super(listIterator);
+        PrefixStepsIterator(Iterator<S> iterator, S initial) {
+            super(iterator);
             this.apsp = Graphs.findAPSP(automaton.transitionGraphView(alphabet));
-            this.initial = automaton.getInitialState();
+            this.initial = initial;
         }
 
         @Override
         protected Iterator<List<I>> l2Iterator(S state) {
-            Iterable<List<I>> lists = IterableUtil.allTuples(alphabet, k);
+            /*
+             * The original code shuffles all tuples globally. Since we can't do this lazily, we approximate this
+             * behavior by at least shuffling the input symbols for a randomized tuple order.
+             */
+            final List<I> inputs = new ArrayList<>(alphabet);
+            Collections.shuffle(inputs, random);
+            final Iterable<List<I>> lists = IterableUtil.allTuples(inputs, k);
             return lists.iterator();
         }
 
         @Override
         protected Word<I> combine(S state, List<I> steps) {
-            List<TransitionEdge<I, T>> prefix = apsp.getShortestPath(initial, state);
+            final List<TransitionEdge<I, T>> prefix = apsp.getShortestPath(initial, state);
             if (prefix == null) {
                 return Word.epsilon();
             }
@@ -384,71 +421,77 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
         private final S endState;
         private final Word<I> steps;
 
+        /**
+         * Since we need to compute the hash code quite often, cache it since we're immutable.
+         */
+        private final int hashCode;
+
         KWayTransition(S startState, S endState, Word<I> steps) {
             this.startState = startState;
             this.endState = endState;
             this.steps = steps;
+
+            this.hashCode = computeHashCode(startState, endState, steps);
+        }
+
+        private int computeHashCode(S startState, S endState, Word<I> steps) {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + Objects.hashCode(startState);
+            result = prime * result + Objects.hashCode(endState);
+            result = prime * result + Objects.hashCode(steps);
+            return result;
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
+            if (this == o) {
+                return true;
+            }
+
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
 
-            KWayTransition<?, ?> that = (KWayTransition<?, ?>) o;
+            final KWayTransition<?, ?> that = (KWayTransition<?, ?>) o;
             return Objects.equals(startState, that.startState) && Objects.equals(endState, that.endState) &&
                    Objects.equals(steps, that.steps);
         }
 
         @Override
         public int hashCode() {
-            int result = Objects.hashCode(startState);
-            result = 31 * result + Objects.hashCode(endState);
-            result = 31 * result + Objects.hashCode(steps);
-            return result;
+            return hashCode;
         }
     }
 
     private static final class Path<S, I> {
 
-        private final S startState;
-        private final S endState;
         private final Word<I> steps;
         private final Set<KWayTransition<S, I>> kWayTransitions;
-        private final List<KWayTransition<S, I>> transitionsLog;
 
-        Path(S startState,
-             S endState,
-             Word<I> steps,
-             Set<KWayTransition<S, I>> kWayTransitions,
-             List<KWayTransition<S, I>> transitionsLog) {
-            this.startState = startState;
-            this.endState = endState;
+        Path(Word<I> steps, Set<KWayTransition<S, I>> kWayTransitions) {
             this.steps = steps;
             this.kWayTransitions = kWayTransitions;
-            this.transitionsLog = transitionsLog;
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
+            if (o == this) {
+                return true;
+            }
+
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
 
-            Path<?, ?> path = (Path<?, ?>) o;
-            return Objects.equals(startState, path.startState) && Objects.equals(endState, path.endState) &&
-                   Objects.equals(steps, path.steps) && Objects.equals(kWayTransitions, path.kWayTransitions) &&
-                   Objects.equals(transitionsLog, path.transitionsLog);
+            final Path<?, ?> path = (Path<?, ?>) o;
+            return Objects.equals(steps, path.steps) && Objects.equals(kWayTransitions, path.kWayTransitions);
         }
 
         @Override
         public int hashCode() {
-            int result = Objects.hashCode(startState);
-            result = 31 * result + Objects.hashCode(endState);
-            result = 31 * result + Objects.hashCode(steps);
+            int result = Objects.hashCode(steps);
             result = 31 * result + Objects.hashCode(kWayTransitions);
-            result = 31 * result + Objects.hashCode(transitionsLog);
             return result;
         }
     }

--- a/util/src/main/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIterator.java
+++ b/util/src/main/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIterator.java
@@ -25,18 +25,18 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
+import java.util.stream.Stream;
 
-import net.automatalib.automaton.UniversalDeterministicAutomaton;
-import net.automatalib.automaton.graph.TransitionEdge;
+import net.automatalib.automaton.DeterministicAutomaton;
 import net.automatalib.common.util.HashUtil;
 import net.automatalib.common.util.collection.AbstractSimplifiedIterator;
 import net.automatalib.common.util.collection.AbstractTwoLevelIterator;
 import net.automatalib.common.util.collection.CollectionUtil;
 import net.automatalib.common.util.collection.IterableUtil;
 import net.automatalib.common.util.collection.IteratorUtil;
+import net.automatalib.common.util.mapping.Mapping;
 import net.automatalib.common.util.random.RandomUtil;
-import net.automatalib.util.graph.Graphs;
-import net.automatalib.util.graph.apsp.APSPResult;
+import net.automatalib.util.automaton.cover.Covers;
 import net.automatalib.word.Word;
 import net.automatalib.word.WordBuilder;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -53,25 +53,42 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * <b>Implementation detail:</b> Note that this test generator heavily relies on the sampling of states. If the given
  * automaton has very few or very many states, the number of generated test cases may be very low or high, respectively.
  * As a result, it may be advisable to {@link IteratorUtil#concat(Iterator[]) combine} this generator with other
- * generators or limit the number of generated test cases.
+ * generators or {@link Stream#limit(long) limit} the number of generated test cases.
  *
  * @param <S>
  *         automaton state type
  * @param <I>
  *         input symbol type
- * @param <T>
- *         transition type
  * @param <A>
  *         automaton type
  */
-public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>>
+public class KWayTransitionCoverTestsIterator<S, I, A extends DeterministicAutomaton<S, I, ?>>
         implements Iterator<Word<I>> {
 
-    public static final int DEFAULT_R_WALK_LEN = 10;
-    public static final int DEFAULT_NUM_GEN_PATHS = 1_000;
-    public static final int DEFAULT_MAX_PATH_LENGTH = 50;
-    public static final int DEFAULT_MAX_NUM_STEPS = 0;
+    /**
+     * The default value of k used in the k-way computations.
+     */
     public static final int DEFAULT_K = 2;
+
+    /**
+     * The default for the maximum step size of {@link GenerationMethod#RANDOM randomly}-generated paths.
+     */
+    public static final int DEFAULT_MAX_PATH_LENGTH = 50;
+
+    /**
+     * The default (unlimited) threshold for the number of steps after which no more new test words will be generated.
+     */
+    public static final int DEFAULT_MAX_NUM_STEPS = 0;
+
+    /**
+     * The default number of {@link GenerationMethod#RANDOM randomly}-generated tests used to find the optimal subset.
+     */
+    public static final int DEFAULT_NUM_GEN_PATHS = 1_000;
+
+    /**
+     * The default number of steps that are appended to {@link GenerationMethod#PREFIX prefix}-generated paths.
+     */
+    public static final int DEFAULT_R_WALK_LEN = 10;
 
     private final A automaton;
     private final List<? extends I> alphabet;
@@ -93,16 +110,18 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
      * @param inputs
      *         the inputs to consider for test case generation
      *
-     * @see #KWayTransitionCoverTestsIterator(UniversalDeterministicAutomaton, Collection, Random)
+     * @see #KWayTransitionCoverTestsIterator(DeterministicAutomaton, Collection, Random)
      */
     public KWayTransitionCoverTestsIterator(A automaton, Collection<? extends I> inputs) {
         this(automaton, inputs, new Random());
     }
 
     /**
-     * Convenience constructor. Uses {@code randomWalkLen=10}, {@code numGeneratePaths = 1_000},
-     * {@code maxPathLen = 50}, {@code maxNumberOfSteps = 0}, {@code k = 2},
-     * {@code optimizationMetric = OptimizationMetric.STEPS}, and {@code generationMethod = GenerationMethod.RANDOM}.
+     * Convenience constructor. Uses <code>randomWalkLen = {@value #DEFAULT_R_WALK_LEN}</code>, <code>numGeneratePaths =
+     * {@value #DEFAULT_NUM_GEN_PATHS}</code>, <code>maxPathLen = {@value #DEFAULT_MAX_PATH_LENGTH}</code>,
+     * <code>maxNumberOfSteps = {@value #DEFAULT_MAX_NUM_STEPS}</code>, <code>k = {@value DEFAULT_K}</code>,
+     * <code>optimizationMetric = {@link OptimizationMetric#STEPS STEPS}</code>, and <code>generationMethod =
+     * {@link GenerationMethod#RANDOM RANDOM}</code>.
      *
      * @param automaton
      *         the automaton for which to generate test cases
@@ -111,8 +130,8 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
      * @param random
      *         the random number generator to use
      *
-     * @see #KWayTransitionCoverTestsIterator(UniversalDeterministicAutomaton, Collection, Random, int, int, int, int,
-     * int, OptimizationMetric, GenerationMethod)
+     * @see #KWayTransitionCoverTestsIterator(DeterministicAutomaton, Collection, Random, int, int, int, int, int,
+     * OptimizationMetric, GenerationMethod)
      */
     public KWayTransitionCoverTestsIterator(A automaton, Collection<? extends I> inputs, Random random) {
         this(automaton,
@@ -137,7 +156,7 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
      * @param random
      *         the random number generator to use
      * @param randomWalkLen
-     *         the number of steps that are added by {@link GenerationMethod#PREFIX prefix}-generated paths
+     *         the number of steps that are appended to {@link GenerationMethod#PREFIX prefix}-generated paths
      * @param numGeneratePaths
      *         number of {@link GenerationMethod#RANDOM randomly}-generated tests used to find the optimal subset
      * @param maxPathLen
@@ -166,9 +185,9 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
         this.alphabet = CollectionUtil.randomAccessList(inputs);
         this.random = random;
 
+        this.randomWalkLen = randomWalkLen;
         this.numGeneratePaths = numGeneratePaths;
         this.maxPathLen = maxPathLen;
-        this.randomWalkLen = randomWalkLen;
         this.maxNumberOfSteps = maxNumberOfSteps;
         this.k = Math.min(k, automaton.size());
         this.optimizationMetric = optimizationMetric;
@@ -280,7 +299,7 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
             this.paths = generateRandomPaths(automaton, initial);
             this.covered = new HashSet<>();
             this.stepCount = 0;
-            this.sizeOfUniverse = automaton.getStates().size() * (int) Math.pow(alphabet.size(), k);
+            this.sizeOfUniverse = Math.multiplyExact(automaton.getStates().size(), (int) Math.pow(alphabet.size(), k));
         }
 
         @Override
@@ -294,7 +313,7 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
                     stepCount += path.steps.size();
                     super.nextValue = path.steps;
 
-                    if (paths.isEmpty()){
+                    if (paths.isEmpty()) {
                         computeNewPaths();
                     }
                     return true;
@@ -316,13 +335,11 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
 
     private class PrefixStepsIterator extends AbstractTwoLevelIterator<S, List<I>, Word<I>> {
 
-        private final APSPResult<S, TransitionEdge<I, T>> apsp;
-        private final S initial;
+        private final Mapping<S, @Nullable Word<I>> accessSequences;
 
         PrefixStepsIterator(Iterator<S> iterator, S initial) {
             super(iterator);
-            this.apsp = Graphs.findAPSP(automaton.transitionGraphView(alphabet));
-            this.initial = initial;
+            this.accessSequences = Covers.cover(automaton, alphabet, initial, w -> {}, w -> {});
         }
 
         @Override
@@ -339,18 +356,16 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
 
         @Override
         protected Word<I> combine(S state, List<I> steps) {
-            final List<TransitionEdge<I, T>> prefix = apsp.getShortestPath(initial, state);
+            final Word<I> prefix = accessSequences.get(state);
             if (prefix == null) {
                 return Word.epsilon();
             }
 
-            final WordBuilder<I> wb = new WordBuilder<>();
-            for (TransitionEdge<I, T> edge : prefix) {
-                wb.append(edge.getInput());
-            }
+            final WordBuilder<I> wb = new WordBuilder<>(prefix.length() + steps.size() + randomWalkLen);
 
-            wb.addAll(steps);
-            wb.addAll(RandomUtil.sample(random, alphabet, randomWalkLen));
+            wb.append(prefix);
+            wb.append(steps);
+            wb.append(RandomUtil.sample(random, alphabet, randomWalkLen));
 
             return wb.toWord();
         }
@@ -386,17 +401,8 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
 
         @Override
         public boolean equals(@Nullable Object o) {
-            if (this == o) {
-                return true;
-            }
-
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            final KWayTransition<?, ?> that = (KWayTransition<?, ?>) o;
-            return Objects.equals(startState, that.startState) && Objects.equals(endState, that.endState) &&
-                   Objects.equals(steps, that.steps);
+            return o == this || o instanceof KWayTransition<?, ?> that && Objects.equals(startState, that.startState) &&
+                                Objects.equals(endState, that.endState) && steps.equals(that.steps);
         }
 
         @Override
@@ -405,37 +411,7 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
         }
     }
 
-    private static final class Path<S, I> {
-
-        private final Word<I> steps;
-        private final Set<KWayTransition<S, I>> kWayTransitions;
-
-        Path(Word<I> steps, Set<KWayTransition<S, I>> kWayTransitions) {
-            this.steps = steps;
-            this.kWayTransitions = kWayTransitions;
-        }
-
-        @Override
-        public boolean equals(@Nullable Object o) {
-            if (o == this) {
-                return true;
-            }
-
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            final Path<?, ?> path = (Path<?, ?>) o;
-            return Objects.equals(steps, path.steps) && Objects.equals(kWayTransitions, path.kWayTransitions);
-        }
-
-        @Override
-        public int hashCode() {
-            int result = Objects.hashCode(steps);
-            result = 31 * result + Objects.hashCode(kWayTransitions);
-            return result;
-        }
-    }
+    private record Path<S, I>(Word<I> steps, Set<KWayTransition<S, I>> kWayTransitions) {}
 
     /**
      * Method by which the prefixes of test words should be generated.
@@ -446,8 +422,8 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
          */
         RANDOM {
             @Override
-            <S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>> Iterator<Word<I>> getIterator(
-                    KWayTransitionCoverTestsIterator<S, I, T, A> self,
+            <S, I, A extends DeterministicAutomaton<S, I, ?>> Iterator<Word<I>> getIterator(
+                    KWayTransitionCoverTestsIterator<S, I, A> self,
                     S initial) {
                 return self.new GreedySetCoverIterator(initial);
             }
@@ -457,15 +433,15 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
          */
         PREFIX {
             @Override
-            <S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>> Iterator<Word<I>> getIterator(
-                    KWayTransitionCoverTestsIterator<S, I, T, A> self,
+            <S, I, A extends DeterministicAutomaton<S, I, ?>> Iterator<Word<I>> getIterator(
+                    KWayTransitionCoverTestsIterator<S, I, A> self,
                     S initial) {
                 return self.generatePrefixSteps(self.automaton, initial);
             }
         };
 
-        abstract <S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>> Iterator<Word<I>> getIterator(
-                KWayTransitionCoverTestsIterator<S, I, T, A> self,
+        abstract <S, I, A extends DeterministicAutomaton<S, I, ?>> Iterator<Word<I>> getIterator(
+                KWayTransitionCoverTestsIterator<S, I, A> self,
                 S initial);
     }
 
@@ -489,7 +465,7 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
         QUERIES {
             @Override
             <S, I> Comparator<Path<S, I>> getPathComparator(Set<KWayTransition<S, I>> covered) {
-                return Comparator.comparingDouble(p -> sizeOfSetDifference(p.kWayTransitions, covered));
+                return Comparator.comparingInt(p -> sizeOfSetDifference(p.kWayTransitions, covered));
             }
         };
 

--- a/util/src/main/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIterator.java
+++ b/util/src/main/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIterator.java
@@ -1,0 +1,348 @@
+package net.automatalib.util.automaton.conformance;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+import java.util.Set;
+import net.automatalib.automaton.UniversalDeterministicAutomaton;
+import net.automatalib.automaton.graph.TransitionEdge;
+import net.automatalib.common.util.HashUtil;
+import net.automatalib.common.util.collection.AbstractSimplifiedIterator;
+import net.automatalib.common.util.collection.AbstractTwoLevelIterator;
+import net.automatalib.common.util.collection.CollectionUtil;
+import net.automatalib.common.util.collection.IterableUtil;
+import net.automatalib.util.graph.Graphs;
+import net.automatalib.util.graph.apsp.APSPResult;
+import net.automatalib.word.Word;
+import net.automatalib.word.WordBuilder;
+
+public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>>
+        implements Iterator<Word<I>> {
+
+    private final A automaton;
+    private final List<? extends I> alphabet;
+    private final Random random;
+    private final int k;
+    private final int numGeneratePaths;
+    private final int maxPathLen;
+    private final int maxNumberOfSteps;
+    private final Optimize optimize;
+    private final int randomWalkLen;
+
+    // Cached paths for reuse
+    private final List<Path<S, I>> cachedPaths = new ArrayList<>();
+
+    private final Iterator<Word<I>> iterator;
+
+    public KWayTransitionCoverTestsIterator(A automaton, Collection<? extends I> inputs) {
+        this(automaton, inputs, new Random());
+    }
+
+    public KWayTransitionCoverTestsIterator(A automaton, Collection<? extends I> inputs, Random random) {
+        this(automaton, inputs, random, 2, Method.Random, 1000, 50, 0, Optimize.Steps, 10);
+    }
+
+    public KWayTransitionCoverTestsIterator(A automaton,
+                                            Collection<? extends I> inputs,
+                                            Random random,
+                                            int k,
+                                            Method method,
+                                            int numGeneratePaths,
+                                            int maxPathLen,
+                                            int maxNumberOfSteps,
+                                            Optimize optimize,
+                                            int randomWalkLen) {
+        this.automaton = automaton;
+        this.alphabet = CollectionUtil.randomAccessList(inputs);
+        this.random = random;
+
+        this.k = k;
+        this.numGeneratePaths = numGeneratePaths;
+        this.maxPathLen = maxPathLen;
+        this.maxNumberOfSteps = maxNumberOfSteps;
+        this.optimize = optimize;
+        this.randomWalkLen = randomWalkLen;
+
+        switch (method) {
+            case Prefix:
+                this.iterator = generatePrefixSteps(automaton).iterator();
+                break;
+            case Random:
+                this.iterator = new GreedySetCoverIterator();
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown method " + method);
+        }
+    }
+
+    @Override
+    public boolean hasNext() {
+        return iterator.hasNext();
+    }
+
+    @Override
+    public Word<I> next() {
+        return iterator.next();
+    }
+
+    private Set<Path<S, I>> generateRandomPaths(A hypothesis) {
+        Set<Path<S, I>> result = new LinkedHashSet<>(HashUtil.capacity(numGeneratePaths));
+
+        for (int i = 0; i < numGeneratePaths; i++) {
+            int randomLength = random.nextInt(maxPathLen - k + 1) + k; // Ensuring length is at least `k`
+            Word<I> steps = KWayStateCoverTestsIterator.getRandomChoices(alphabet, randomLength, random);
+            Path<S, I> path = createPath(hypothesis, steps);
+            result.add(path);
+        }
+
+        return result;
+    }
+
+    /**
+     * * Creates Path object from provided automaton steps within specified Hypothesis context.** * *@return Newly
+     * created Path instance corresponding to provided step sequence.**
+     **/
+    private Path<S, I> createPath(A hypothesis, Word<I> steps) {
+        Set<KWayTransition<S, I>> transitions = new HashSet<>();
+        List<KWayTransition<S, I>> transitionsLog = new ArrayList<>();
+
+        List<S> prevStates = new ArrayList<>(steps.size());
+        List<S> endStates = new ArrayList<>(steps.size());
+
+        S iter = hypothesis.getInitialState();
+
+        for (I i : steps) {
+            prevStates.add(iter);
+            iter = hypothesis.getSuccessor(iter, i);
+            endStates.add(iter);
+        }
+
+        for (int i = 0; i < steps.size() - k + 1; i++) {
+            S prevState = prevStates.get(i);
+            S endState = endStates.get(i + k - 1);
+            Word<I> chunk = steps.subWord(i, i + k);
+
+            KWayTransition<S, I> transition = new KWayTransition<>(prevState, endState, chunk);
+
+            transitionsLog.add(transition);
+            transitions.add(transition);
+        }
+
+        return new Path<>(hypothesis.getInitialState(),
+                          endStates.get(endStates.size() - 1),
+                          steps,
+                          transitions,
+                          transitionsLog);
+    }
+
+    public Iterable<Word<I>> generatePrefixSteps(A hypothesis) {
+        List<S> states = new ArrayList<>(hypothesis.getStates());
+        Collections.reverse(states);
+        return () -> new PrefixStepsIterator(states.iterator());
+    }
+
+    /**
+     * Selects an optimal path from available candidates based on optimization strategy defined.
+     *
+     * @return Selected Path object or null if no suitable path is found.
+     **/
+    private Path<S, I> selectOptimalPath(Set<KWayTransition<S, I>> covered, Collection<Path<S, I>> paths) {
+        Path<S, I> max = Collections.max(paths, optimize.getPathComparator(covered));
+        return max.kWayTransitions.size() != covered.size() ? max : null;
+    }
+
+    private static <I> List<I> getRandomChoices(List<? extends I> alphabet, int count, Random random) {
+        List<I> choices = new ArrayList<>(count);
+
+        for (int i = 0; i < count; i++) {
+            choices.add(alphabet.get(random.nextInt(alphabet.size())));
+        }
+
+        return choices;
+    }
+
+    public enum Method {
+        Random,
+        Prefix
+    }
+
+    public enum Optimize {
+        Steps {
+            @Override
+            <S, I> Comparator<Path<S, I>> getPathComparator(Set<KWayTransition<S, I>> covered) {
+                return Comparator.comparingDouble(p -> ((double) (p.kWayTransitions.size() - covered.size())) /
+                                                       p.steps.size());
+            }
+        },
+        Queries {
+            @Override
+            <S, I> Comparator<Path<S, I>> getPathComparator(Set<KWayTransition<S, I>> covered) {
+                return Comparator.comparingDouble(p -> (p.kWayTransitions.size() - covered.size()));
+            }
+        };
+
+        abstract <S, I> Comparator<Path<S, I>> getPathComparator(Set<KWayTransition<S, I>> covered);
+    }
+
+    private class GreedySetCoverIterator extends AbstractSimplifiedIterator<Word<I>> {
+
+        private final Set<Path<S, I>> paths;
+        private final int sizeOfUniverse;
+        private final Set<KWayTransition<S, I>> covered;
+
+        private int stepCount;
+
+        public GreedySetCoverIterator() {
+            this.paths = generateRandomPaths(automaton);
+            this.paths.addAll(cachedPaths);
+            this.covered = new HashSet<>();
+            this.stepCount = 0;
+            this.sizeOfUniverse = automaton.getStates().size() * (int) Math.pow(alphabet.size(), k);
+        }
+
+        @Override
+        protected boolean calculateNext() {
+            if (sizeOfUniverse > covered.size()) {
+                Path<S, I> path = selectOptimalPath(covered, paths);
+
+                if (path != null) {
+                    covered.addAll(path.kWayTransitions);
+                    paths.remove(path);
+                    stepCount += path.steps.size();
+//                    result.add(path);
+                    super.nextValue = path.steps;
+                    return true;
+                }
+
+                if (paths.isEmpty()) {
+                    for (Word<I> generatePrefixStep : generatePrefixSteps(automaton)) {
+                        paths.add(createPath(automaton, generatePrefixStep));
+                    }
+                }
+
+                if (maxNumberOfSteps != 0 && stepCount > maxNumberOfSteps) {
+                    return false;
+                }
+            }
+            return false;
+        }
+    }
+
+    private class PrefixStepsIterator extends AbstractTwoLevelIterator<S, List<I>, Word<I>> {
+
+        private final APSPResult<S, TransitionEdge<I, T>> apsp;
+        private final S initial;
+
+        public PrefixStepsIterator(Iterator<S> listIterator) {
+            super(listIterator);
+            this.apsp = Graphs.findAPSP(automaton.transitionGraphView(alphabet));
+            this.initial = automaton.getInitialState();
+        }
+
+        @Override
+        protected Iterator<List<I>> l2Iterator(S state) {
+            Iterable<List<I>> lists = IterableUtil.allTuples(alphabet, k);
+            return lists.iterator();
+        }
+
+        @Override
+        protected Word<I> combine(S state, List<I> steps) {
+            List<TransitionEdge<I, T>> prefix = apsp.getShortestPath(initial, state);
+            if (prefix == null) {
+                return Word.epsilon();
+            }
+
+            final WordBuilder<I> wb = new WordBuilder<>();
+            for (TransitionEdge<I, T> edge : prefix) {
+                wb.append(edge.getInput());
+            }
+
+            wb.addAll(steps);
+            wb.addAll(getRandomChoices(alphabet, randomWalkLen, random));
+
+            return wb.toWord();
+        }
+    }
+
+    private static final class KWayTransition<S, I> {
+
+        private final S startState;
+        private final S endState;
+        private final Word<I> steps;
+
+        private KWayTransition(S startState, S endState, Word<I> steps) {
+            this.startState = startState;
+            this.endState = endState;
+            this.steps = steps;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            KWayTransition<?, ?> that = (KWayTransition<?, ?>) o;
+            return Objects.equals(startState, that.startState) && Objects.equals(endState, that.endState) &&
+                   Objects.equals(steps, that.steps);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = Objects.hashCode(startState);
+            result = 31 * result + Objects.hashCode(endState);
+            result = 31 * result + Objects.hashCode(steps);
+            return result;
+        }
+    }
+
+    private static final class Path<S, I> {
+
+        private final S startState;
+        private final S endState;
+        private final Word<I> steps;
+        private final Set<KWayTransition<S, I>> kWayTransitions;
+        private final List<KWayTransition<S, I>> transitionsLog;
+
+        private Path(S startState,
+                     S endState,
+                     Word<I> steps,
+                     Set<KWayTransition<S, I>> kWayTransitions,
+                     List<KWayTransition<S, I>> transitionsLog) {
+            this.startState = startState;
+            this.endState = endState;
+            this.steps = steps;
+            this.kWayTransitions = kWayTransitions;
+            this.transitionsLog = transitionsLog;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Path<?, ?> path = (Path<?, ?>) o;
+            return Objects.equals(startState, path.startState) && Objects.equals(endState, path.endState) &&
+                   Objects.equals(steps, path.steps) && Objects.equals(kWayTransitions, path.kWayTransitions) &&
+                   Objects.equals(transitionsLog, path.transitionsLog);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = Objects.hashCode(startState);
+            result = 31 * result + Objects.hashCode(endState);
+            result = 31 * result + Objects.hashCode(steps);
+            result = 31 * result + Objects.hashCode(kWayTransitions);
+            result = 31 * result + Objects.hashCode(transitionsLog);
+            return result;
+        }
+    }
+}

--- a/util/src/main/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIterator.java
+++ b/util/src/main/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIterator.java
@@ -70,12 +70,12 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
     private final A automaton;
     private final List<? extends I> alphabet;
     private final Random random;
-    private final int k;
+    private final int randomWalkLen;
     private final int numGeneratePaths;
     private final int maxPathLen;
     private final int maxNumberOfSteps;
+    private final int k;
     private final OptimizationMetric optimizationMetric;
-    private final int randomWalkLen;
 
     private final Iterator<Word<I>> iterator;
 
@@ -96,7 +96,7 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
     /**
      * Convenience constructor. Uses {@code randomWalkLen=10}, {@code numGeneratePaths = 1_000},
      * {@code maxPathLen = 50}, {@code maxNumberOfSteps = 0}, {@code k = 2},
-     * {@code generationMethod = GenerationMethod.RANDOM}, and {@code optimizationMetric = OptimizationMetric.STEPS}.
+     * {@code optimizationMetric = OptimizationMetric.STEPS}, and {@code generationMethod = GenerationMethod.RANDOM}.
      *
      * @param automaton
      *         the automaton for which to generate test cases
@@ -106,7 +106,7 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
      *         the random number generator to use
      *
      * @see #KWayTransitionCoverTestsIterator(UniversalDeterministicAutomaton, Collection, Random, int, int, int, int,
-     * int, GenerationMethod, OptimizationMetric)
+     * int, OptimizationMetric, GenerationMethod)
      */
     public KWayTransitionCoverTestsIterator(A automaton, Collection<? extends I> inputs, Random random) {
         this(automaton,
@@ -117,8 +117,8 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
              DEFAULT_MAX_PATH_LENGTH,
              DEFAULT_MAX_NUM_STEPS,
              DEFAULT_K,
-             GenerationMethod.RANDOM,
-             OptimizationMetric.STEPS);
+             OptimizationMetric.STEPS,
+             GenerationMethod.RANDOM);
     }
 
     /**
@@ -133,7 +133,7 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
      * @param randomWalkLen
      *         the number of steps that are added by {@link GenerationMethod#PREFIX prefix}-generated paths
      * @param numGeneratePaths
-     *         number of {@link GenerationMethod#RANDOM randomly}-generated queries used to find the optimal subset
+     *         number of {@link GenerationMethod#RANDOM randomly}-generated tests used to find the optimal subset
      * @param maxPathLen
      *         the maximum step size of {@link GenerationMethod#RANDOM randomly}-generated paths
      * @param maxNumberOfSteps
@@ -141,10 +141,10 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
      * @param k
      *         k value used for K-Way transitions, i.e.,the number of steps between the start and the end of a
      *         transition
-     * @param generationMethod
-     *         defines how the queries are generated
      * @param optimizationMetric
      *         the metric after which test cases are minimized
+     * @param generationMethod
+     *         defines how the tests are generated
      */
     public KWayTransitionCoverTestsIterator(A automaton,
                                             Collection<? extends I> inputs,
@@ -154,18 +154,18 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
                                             int maxPathLen,
                                             int maxNumberOfSteps,
                                             int k,
-                                            GenerationMethod generationMethod,
-                                            OptimizationMetric optimizationMetric) {
+                                            OptimizationMetric optimizationMetric,
+                                            GenerationMethod generationMethod) {
         this.automaton = automaton;
         this.alphabet = CollectionUtil.randomAccessList(inputs);
         this.random = random;
 
-        this.k = Math.min(k, automaton.size());
         this.numGeneratePaths = numGeneratePaths;
         this.maxPathLen = maxPathLen;
-        this.maxNumberOfSteps = maxNumberOfSteps;
-        this.optimizationMetric = optimizationMetric;
         this.randomWalkLen = randomWalkLen;
+        this.maxNumberOfSteps = maxNumberOfSteps;
+        this.k = Math.min(k, automaton.size());
+        this.optimizationMetric = optimizationMetric;
 
         final S initial = automaton.getInitialState();
 
@@ -174,6 +174,7 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
         } else {
             this.iterator = generationMethod.getIterator(this, initial);
         }
+
     }
 
     @Override
@@ -263,65 +264,6 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
             }
         }
         return size;
-    }
-
-    /**
-     * Method by which the prefixes of test words should be generated.
-     */
-    public enum GenerationMethod {
-        /**
-         * Generate prefixes randomly.
-         */
-        RANDOM {
-            @Override
-            <S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>> Iterator<Word<I>> getIterator(
-                    KWayTransitionCoverTestsIterator<S, I, T, A> self,
-                    S initial) {
-                return self.new GreedySetCoverIterator(initial);
-            }
-        },
-        /**
-         * Generate prefixes based on access sequences.
-         */
-        PREFIX {
-            @Override
-            <S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>> Iterator<Word<I>> getIterator(
-                    KWayTransitionCoverTestsIterator<S, I, T, A> self,
-                    S initial) {
-                return self.generatePrefixSteps(self.automaton, initial);
-            }
-        };
-
-        abstract <S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>> Iterator<Word<I>> getIterator(
-                KWayTransitionCoverTestsIterator<S, I, T, A> self,
-                S initial);
-    }
-
-    /**
-     * The metric by which to optimize path selection.
-     */
-    public enum OptimizationMetric {
-        /**
-         * Selects the paths maximum coverage per step, thus reducing the number of total steps.
-         */
-        STEPS {
-            @Override
-            <S, I> Comparator<Path<S, I>> getPathComparator(Set<KWayTransition<S, I>> covered) {
-                return Comparator.comparingDouble(p -> ((double) sizeOfSetDifference(p.kWayTransitions, covered)) /
-                                                       p.steps.size());
-            }
-        },
-        /**
-         * Selects the paths with maximum coverage, thus reducing number of test words.
-         */
-        QUERIES {
-            @Override
-            <S, I> Comparator<Path<S, I>> getPathComparator(Set<KWayTransition<S, I>> covered) {
-                return Comparator.comparingDouble(p -> sizeOfSetDifference(p.kWayTransitions, covered));
-            }
-        };
-
-        abstract <S, I> Comparator<Path<S, I>> getPathComparator(Set<KWayTransition<S, I>> covered);
     }
 
     private class GreedySetCoverIterator extends AbstractSimplifiedIterator<Word<I>> {
@@ -494,5 +436,64 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
             result = 31 * result + Objects.hashCode(kWayTransitions);
             return result;
         }
+    }
+
+    /**
+     * Method by which the prefixes of test words should be generated.
+     */
+    public enum GenerationMethod {
+        /**
+         * Generate prefixes randomly.
+         */
+        RANDOM {
+            @Override
+            <S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>> Iterator<Word<I>> getIterator(
+                    KWayTransitionCoverTestsIterator<S, I, T, A> self,
+                    S initial) {
+                return self.new GreedySetCoverIterator(initial);
+            }
+        },
+        /**
+         * Generate prefixes based on access sequences.
+         */
+        PREFIX {
+            @Override
+            <S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>> Iterator<Word<I>> getIterator(
+                    KWayTransitionCoverTestsIterator<S, I, T, A> self,
+                    S initial) {
+                return self.generatePrefixSteps(self.automaton, initial);
+            }
+        };
+
+        abstract <S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>> Iterator<Word<I>> getIterator(
+                KWayTransitionCoverTestsIterator<S, I, T, A> self,
+                S initial);
+    }
+
+    /**
+     * The metric by which to optimize path selection.
+     */
+    public enum OptimizationMetric {
+        /**
+         * Selects the paths maximum coverage per step, thus reducing the number of total steps.
+         */
+        STEPS {
+            @Override
+            <S, I> Comparator<Path<S, I>> getPathComparator(Set<KWayTransition<S, I>> covered) {
+                return Comparator.comparingDouble(p -> ((double) sizeOfSetDifference(p.kWayTransitions, covered)) /
+                                                       p.steps.size());
+            }
+        },
+        /**
+         * Selects the paths with maximum coverage, thus reducing number of test words.
+         */
+        QUERIES {
+            @Override
+            <S, I> Comparator<Path<S, I>> getPathComparator(Set<KWayTransition<S, I>> covered) {
+                return Comparator.comparingDouble(p -> sizeOfSetDifference(p.kWayTransitions, covered));
+            }
+        };
+
+        abstract <S, I> Comparator<Path<S, I>> getPathComparator(Set<KWayTransition<S, I>> covered);
     }
 }

--- a/util/src/main/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIterator.java
+++ b/util/src/main/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIterator.java
@@ -34,19 +34,38 @@ import net.automatalib.common.util.collection.AbstractSimplifiedIterator;
 import net.automatalib.common.util.collection.AbstractTwoLevelIterator;
 import net.automatalib.common.util.collection.CollectionUtil;
 import net.automatalib.common.util.collection.IterableUtil;
+import net.automatalib.common.util.random.RandomUtil;
 import net.automatalib.util.graph.Graphs;
 import net.automatalib.util.graph.apsp.APSPResult;
 import net.automatalib.word.Word;
 import net.automatalib.word.WordBuilder;
 
+/**
+ * A randomized state cover test generator based on the concepts of mutation testing as described in the paper <a
+ * href="https://doi.org/10.1007/978-3-319-57288-8_2">Learning from Faults: Mutation Testing in Active Automata
+ * Learning</a> by Bernhard K. Aichernig and Martin Tappler.
+ * <p>
+ * This iterates selects test cases based on k-way transitions coverage. It does that by generating random test words
+ * and finding the smallest subset with the highest coverage. In other words, this iterator generates test words by
+ * running random paths that cover all pairwise / k-way transitions.
+ *
+ * @param <S>
+ *         automaton state type
+ * @param <I>
+ *         input symbol type
+ * @param <T>
+ *         transition type
+ * @param <A>
+ *         automaton type
+ */
 public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>>
         implements Iterator<Word<I>> {
 
-    private static final int DEFAULT_K = 2;
-    private static final int DEFAULT_NUM_GENERATED_PATHS = 1_000;
-    private static final int DEFAULT_MAX_PATH_LENGTH = 50;
-    private static final int DEFAULT_MAX_NUMBER_OF_STEPS = 0;
-    private static final int DEFAULT_RANDOM_WALK_LENGTH = 10;
+    public static final int DEFAULT_R_WALK_LEN = 10;
+    public static final int DEFAULT_NUM_GEN_PATHS = 1_000;
+    public static final int DEFAULT_MAX_PATH_LENGTH = 50;
+    public static final int DEFAULT_MAX_NUM_STEPS = 0;
+    public static final int DEFAULT_K = 2;
 
     private final A automaton;
     private final List<? extends I> alphabet;
@@ -55,61 +74,105 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
     private final int numGeneratePaths;
     private final int maxPathLen;
     private final int maxNumberOfSteps;
-    private final Optimize optimize;
+    private final OptimizationMetric optimizationMetric;
     private final int randomWalkLen;
-
-    // Cached paths for reuse
-    private final List<Path<S, I>> cachedPaths = new ArrayList<>();
 
     private final Iterator<Word<I>> iterator;
 
+    /**
+     * Convenience constructor which uses a fresh {@code random} object.
+     *
+     * @param automaton
+     *         the automaton for which to generate test cases
+     * @param inputs
+     *         the inputs to consider for test case generation
+     *
+     * @see #KWayTransitionCoverTestsIterator(UniversalDeterministicAutomaton, Collection, Random)
+     */
     public KWayTransitionCoverTestsIterator(A automaton, Collection<? extends I> inputs) {
         this(automaton, inputs, new Random());
     }
 
+    /**
+     * Convenience constructor. Uses {@code randomWalkLen=10}, {@code numGeneratePaths = 1_000},
+     * {@code maxPathLen = 50}, {@code maxNumberOfSteps = 0}, {@code k = 2},
+     * {@code generationMethod = GenerationMethod.RANDOM}, and {@code optimizationMetric = OptimizationMetric.STEPS}.
+     *
+     * @param automaton
+     *         the automaton for which to generate test cases
+     * @param inputs
+     *         the inputs to consider for test case generation
+     * @param random
+     *         the random number generator to use
+     *
+     * @see #KWayTransitionCoverTestsIterator(UniversalDeterministicAutomaton, Collection, Random, int, int, int, int,
+     * int, GenerationMethod, OptimizationMetric)
+     */
     public KWayTransitionCoverTestsIterator(A automaton, Collection<? extends I> inputs, Random random) {
         this(automaton,
              inputs,
              random,
-             DEFAULT_K,
-             Method.RANDOM,
-             DEFAULT_NUM_GENERATED_PATHS,
+             DEFAULT_R_WALK_LEN,
+             DEFAULT_NUM_GEN_PATHS,
              DEFAULT_MAX_PATH_LENGTH,
-             DEFAULT_MAX_NUMBER_OF_STEPS,
-             Optimize.STEPS,
-             DEFAULT_RANDOM_WALK_LENGTH);
+             DEFAULT_MAX_NUM_STEPS,
+             DEFAULT_K,
+             GenerationMethod.RANDOM,
+             OptimizationMetric.STEPS);
     }
 
+    /**
+     * Constructor.
+     *
+     * @param automaton
+     *         the automaton for which to generate test cases
+     * @param inputs
+     *         the inputs to consider for test case generation
+     * @param random
+     *         the random number generator to use
+     * @param randomWalkLen
+     *         the number of steps that are added by 'prefix' generated paths
+     * @param numGeneratePaths
+     *         number of random queries used to find the optimal subset
+     * @param maxPathLen
+     *         the maximum step size of a generated path
+     * @param maxNumberOfSteps
+     *         maximum number of steps that will be executed on the automaton (<=0 = no limit)
+     * @param k
+     *         k value used for K-Way transitions, i.e the number of steps between the start and the end of a
+     *         transition
+     * @param generationMethod
+     *         defines how the queries are generated 'random' or 'prefix'
+     * @param optimizationMetric
+     *         minimize either the number of 'steps' or 'queries' that are executed
+     */
     public KWayTransitionCoverTestsIterator(A automaton,
                                             Collection<? extends I> inputs,
                                             Random random,
-                                            int k,
-                                            Method method,
+                                            int randomWalkLen,
                                             int numGeneratePaths,
                                             int maxPathLen,
                                             int maxNumberOfSteps,
-                                            Optimize optimize,
-                                            int randomWalkLen) {
+                                            int k,
+                                            GenerationMethod generationMethod,
+                                            OptimizationMetric optimizationMetric) {
         this.automaton = automaton;
         this.alphabet = CollectionUtil.randomAccessList(inputs);
         this.random = random;
 
-        this.k = k;
+        this.k = Math.min(k, automaton.size());
         this.numGeneratePaths = numGeneratePaths;
         this.maxPathLen = maxPathLen;
         this.maxNumberOfSteps = maxNumberOfSteps;
-        this.optimize = optimize;
+        this.optimizationMetric = optimizationMetric;
         this.randomWalkLen = randomWalkLen;
 
-        switch (method) {
-            case PREFIX:
-                this.iterator = generatePrefixSteps(automaton);
-                break;
-            case RANDOM:
-                this.iterator = new GreedySetCoverIterator();
-                break;
-            default:
-                this.iterator = Collections.emptyIterator();
+        final S initial = automaton.getInitialState();
+
+        if (automaton.size() == 0 || initial == null) {
+            this.iterator = Collections.emptyIterator();
+        } else {
+            this.iterator = generationMethod.getIterator(this);
         }
     }
 
@@ -128,7 +191,7 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
 
         for (int i = 0; i < numGeneratePaths; i++) {
             int randomLength = random.nextInt(maxPathLen - k + 1) + k; // Ensuring length is at least `k`
-            Word<I> steps = KWayStateCoverTestsIterator.getRandomChoices(alphabet, randomLength, random);
+            Word<I> steps = Word.fromList(RandomUtil.sample(random, alphabet, randomLength));
             Path<S, I> path = createPath(hypothesis, steps);
             result.add(path);
         }
@@ -176,17 +239,31 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
     }
 
     private Path<S, I> selectOptimalPath(Set<KWayTransition<S, I>> covered, Collection<Path<S, I>> paths) {
-        Path<S, I> max = Collections.max(paths, optimize.getPathComparator(covered));
-        // require max to provide new transitions
-        return covered.containsAll(max.kWayTransitions) ? null : max;
+        Path<S, I> max = Collections.max(paths, optimizationMetric.getPathComparator(covered));
+        return max.kWayTransitions.size() == covered.size() ? null : max;
     }
 
-    public enum Method {
-        RANDOM,
-        PREFIX
+    public enum GenerationMethod {
+        RANDOM {
+            @Override
+            <S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>> Iterator<Word<I>> getIterator(
+                    KWayTransitionCoverTestsIterator<S, I, T, A> self) {
+                return self.new GreedySetCoverIterator();
+            }
+        },
+        PREFIX {
+            @Override
+            <S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>> Iterator<Word<I>> getIterator(
+                    KWayTransitionCoverTestsIterator<S, I, T, A> self) {
+                return self.generatePrefixSteps(self.automaton);
+            }
+        };
+
+        abstract <S, I, T, A extends UniversalDeterministicAutomaton<S, I, T, ?, ?>> Iterator<Word<I>> getIterator(
+                KWayTransitionCoverTestsIterator<S, I, T, A> self);
     }
 
-    public enum Optimize {
+    public enum OptimizationMetric {
         STEPS {
             @Override
             <S, I> Comparator<Path<S, I>> getPathComparator(Set<KWayTransition<S, I>> covered) {
@@ -197,7 +274,7 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
         QUERIES {
             @Override
             <S, I> Comparator<Path<S, I>> getPathComparator(Set<KWayTransition<S, I>> covered) {
-                return Comparator.comparingDouble(p -> computeSizeOfDiff(p.kWayTransitions, covered));
+                return Comparator.comparingDouble(p -> p.kWayTransitions.size() - covered.size());
             }
         };
 
@@ -231,7 +308,6 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
 
         GreedySetCoverIterator() {
             this.paths = generateRandomPaths(automaton);
-            this.paths.addAll(cachedPaths);
             this.covered = new HashSet<>();
             this.stepCount = 0;
             this.sizeOfUniverse = automaton.getStates().size() * (int) Math.pow(alphabet.size(), k);
@@ -246,7 +322,6 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
                     covered.addAll(path.kWayTransitions);
                     paths.remove(path);
                     stepCount += path.steps.size();
-                    //result.add(path);
                     super.nextValue = path.steps;
                     return true;
                 }
@@ -296,8 +371,8 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
                 wb.append(edge.getInput());
             }
 
-            wb.append(steps);
-            wb.append(KWayStateCoverTestsIterator.getRandomChoices(alphabet, randomWalkLen, random));
+            wb.addAll(steps);
+            wb.addAll(RandomUtil.sample(random, alphabet, randomWalkLen));
 
             return wb.toWord();
         }

--- a/util/src/main/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIterator.java
+++ b/util/src/main/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIterator.java
@@ -162,7 +162,8 @@ public class KWayTransitionCoverTestsIterator<S, I, A extends DeterministicAutom
      * @param maxPathLen
      *         the maximum step size of {@link GenerationMethod#RANDOM randomly}-generated paths
      * @param maxNumberOfSteps
-     *         threshold for the number of steps after which no more new test words will be generated (<=0 = no limit)
+     *         threshold for the number of steps after which no more new test words will be generated (a value less than
+     *         zero means no limit)
      * @param k
      *         k value used for K-Way transitions, i.e.,the number of steps between the start and the end of a
      *         transition

--- a/util/src/main/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIterator.java
+++ b/util/src/main/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIterator.java
@@ -33,6 +33,7 @@ import net.automatalib.common.util.collection.AbstractSimplifiedIterator;
 import net.automatalib.common.util.collection.AbstractTwoLevelIterator;
 import net.automatalib.common.util.collection.CollectionUtil;
 import net.automatalib.common.util.collection.IterableUtil;
+import net.automatalib.common.util.collection.IteratorUtil;
 import net.automatalib.common.util.random.RandomUtil;
 import net.automatalib.util.graph.Graphs;
 import net.automatalib.util.graph.apsp.APSPResult;
@@ -48,6 +49,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * This iterator selects test cases based on k-way transitions coverage. It does that by generating random test words
  * and finding the smallest subset with the highest coverage. In other words, this iterator generates test words by
  * running random paths that cover all pairwise / k-way transitions.
+ * <p>
+ * <b>Implementation detail:</b> Note that this test generator heavily relies on the sampling of states. If the given
+ * automaton has very few or very many states, the number of generated test cases may be very low or high, respectively.
+ * As a result, it may be advisable to {@link IteratorUtil#concat(Iterator[]) combine} this generator with other
+ * generators or limit the number of generated test cases.
  *
  * @param <S>
  *         automaton state type

--- a/util/src/main/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIterator.java
+++ b/util/src/main/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIterator.java
@@ -203,26 +203,20 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
     private Path<S, I> createPath(A hypothesis, S initial, Word<I> steps) {
         final Set<KWayTransition<S, I>> transitions = new HashSet<>();
 
-        final List<S> prevStates = new ArrayList<>(steps.size());
-        final List<S> endStates = new ArrayList<>(steps.size());
+        final List<@Nullable S> prevStates = new ArrayList<>(steps.size());
+        final List<@Nullable S> endStates = new ArrayList<>(steps.size());
 
         S iter = initial;
-        Word<I> reachableSteps = steps;
 
-        for (int i = 0; i < steps.length(); i++) {
-            final S succ = hypothesis.getSuccessor(iter, steps.getSymbol(i));
-            if (succ == null) {
-                reachableSteps = steps.subWord(0, i);
-            } else {
-                prevStates.add(iter);
-                endStates.add(succ);
-                iter = succ;
-            }
+        for (I i : steps) {
+            prevStates.add(iter);
+            iter = iter == null ? null : hypothesis.getSuccessor(iter, i);
+            endStates.add(iter);
         }
 
-        for (int i = 0; i < reachableSteps.size() - k + 1; i++) {
-            final S prevState = prevStates.get(i);
-            final S endState = endStates.get(i + k - 1);
+        for (int i = 0; i < steps.size() - k + 1; i++) {
+            final @Nullable S prevState = prevStates.get(i);
+            final @Nullable S endState = endStates.get(i + k - 1);
             final Word<I> chunk = steps.subWord(i, i + k);
 
             final KWayTransition<S, I> transition = new KWayTransition<>(prevState, endState, chunk);
@@ -285,7 +279,7 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
 
         @Override
         protected boolean calculateNext() {
-            while (sizeOfUniverse > covered.size()) {
+            while (sizeOfUniverse > covered.size() && (maxNumberOfSteps == 0 || stepCount <= maxNumberOfSteps)) {
                 final Path<S, I> path = selectOptimalPath(covered, paths);
 
                 if (path != null) {
@@ -293,25 +287,24 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
                     paths.remove(path);
                     stepCount += path.steps.size();
                     super.nextValue = path.steps;
-                    return true;
-                }
 
-                if (paths.isEmpty()) {
-                    final Iterator<Word<I>> prefixIterator = generatePrefixSteps(automaton, initial);
-                    while (prefixIterator.hasNext()) {
-                        final Word<I> generatePrefixStep = prefixIterator.next();
-                        paths.add(createPath(automaton, initial, generatePrefixStep));
+                    if (paths.isEmpty()){
+                        computeNewPaths();
                     }
+                    return true;
                 } else {
-                    // prevent infinite loops
-                    return false;
-                }
-
-                if (maxNumberOfSteps != 0 && stepCount > maxNumberOfSteps) {
-                    return false;
+                    computeNewPaths();
                 }
             }
             return false;
+        }
+
+        private void computeNewPaths() {
+            final Iterator<Word<I>> prefixIterator = generatePrefixSteps(automaton, initial);
+            while (prefixIterator.hasNext()) {
+                final Word<I> generatePrefixStep = prefixIterator.next();
+                paths.add(createPath(automaton, initial, generatePrefixStep));
+            }
         }
     }
 
@@ -359,8 +352,8 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
 
     private static final class KWayTransition<S, I> {
 
-        private final S startState;
-        private final S endState;
+        private final @Nullable S startState;
+        private final @Nullable S endState;
         private final Word<I> steps;
 
         /**
@@ -368,7 +361,7 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
          */
         private final int hashCode;
 
-        KWayTransition(S startState, S endState, Word<I> steps) {
+        KWayTransition(@Nullable S startState, @Nullable S endState, Word<I> steps) {
             this.startState = startState;
             this.endState = endState;
             this.steps = steps;
@@ -376,7 +369,7 @@ public class KWayTransitionCoverTestsIterator<S, I, T, A extends UniversalDeterm
             this.hashCode = computeHashCode(startState, endState, steps);
         }
 
-        private int computeHashCode(S startState, S endState, Word<I> steps) {
+        private int computeHashCode(@Nullable S startState, @Nullable S endState, Word<I> steps) {
             final int prime = 31;
             int result = 1;
             result = prime * result + Objects.hashCode(startState);

--- a/util/src/main/java/net/automatalib/util/automaton/cover/Covers.java
+++ b/util/src/main/java/net/automatalib/util/automaton/cover/Covers.java
@@ -26,8 +26,10 @@ import java.util.function.Consumer;
 
 import net.automatalib.automaton.DeterministicAutomaton;
 import net.automatalib.common.util.HashUtil;
+import net.automatalib.common.util.mapping.Mapping;
 import net.automatalib.common.util.mapping.MutableMapping;
 import net.automatalib.word.Word;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class Covers {
 
@@ -48,13 +50,15 @@ public final class Covers {
      *         the set of input symbols allowed in the cover sequences
      * @param states
      *         the collection in which the sequences will be stored
+     * @param <S>
+     *         automaton state type
      * @param <I>
      *         input symbol type
      */
-    public static <I> void stateCover(DeterministicAutomaton<?, I, ?> automaton,
-                                      Collection<? extends I> inputs,
-                                      Collection<? super Word<I>> states) {
-        cover(automaton, inputs, states::add, w -> {});
+    public static <S, I> void stateCover(DeterministicAutomaton<S, I, ?> automaton,
+                                         Collection<? extends I> inputs,
+                                         Collection<? super Word<I>> states) {
+        cover(automaton, inputs, automaton.getInitialState(), states::add, w -> {});
     }
 
     /**
@@ -93,13 +97,15 @@ public final class Covers {
      *         the set of input symbols allowed in the cover sequences
      * @param transitions
      *         the collection in which the sequences will be stored
+     * @param <S>
+     *         automaton state type
      * @param <I>
      *         input symbol type
      */
-    public static <I> void transitionCover(DeterministicAutomaton<?, I, ?> automaton,
-                                           Collection<? extends I> inputs,
-                                           Collection<? super Word<I>> transitions) {
-        cover(automaton, inputs, w -> {}, transitions::add);
+    public static <S, I> void transitionCover(DeterministicAutomaton<S, I, ?> automaton,
+                                              Collection<? extends I> inputs,
+                                              Collection<? super Word<I>> transitions) {
+        cover(automaton, inputs, automaton.getInitialState(), w -> {}, transitions::add);
     }
 
     /**
@@ -133,16 +139,18 @@ public final class Covers {
      *         the set of input symbols allowed in the cover sequences
      * @param cover
      *         the collection in which the sequences will be stored
+     * @param <S>
+     *         automaton state type
      * @param <I>
      *         input symbol type
      *
      * @see #stateCover(DeterministicAutomaton, Collection, Collection)
      * @see #transitionCover(DeterministicAutomaton, Collection, Collection)
      */
-    public static <I> void structuralCover(DeterministicAutomaton<?, I, ?> automaton,
-                                           Collection<? extends I> inputs,
-                                           Collection<? super Word<I>> cover) {
-        cover(automaton, inputs, cover::add, cover::add);
+    public static <S, I> void structuralCover(DeterministicAutomaton<S, I, ?> automaton,
+                                              Collection<? extends I> inputs,
+                                              Collection<? super Word<I>> cover) {
+        cover(automaton, inputs, automaton.getInitialState(), cover::add, cover::add);
     }
 
     /**
@@ -156,35 +164,67 @@ public final class Covers {
      *         the collection in which the state cover sequences will be stored
      * @param transitions
      *         the collection in which the transition cover sequences will be stored
+     * @param <S>
+     *         automaton state type
      * @param <I>
      *         input symbol type
      *
      * @see #stateCover(DeterministicAutomaton, Collection, Collection)
      * @see #transitionCover(DeterministicAutomaton, Collection, Collection)
      */
-    public static <I> void cover(DeterministicAutomaton<?, I, ?> automaton,
-                                 Collection<? extends I> inputs,
-                                 Collection<? super Word<I>> states,
-                                 Collection<? super Word<I>> transitions) {
-        cover(automaton, inputs, states::add, transitions::add);
+    public static <S, I> void cover(DeterministicAutomaton<S, I, ?> automaton,
+                                    Collection<? extends I> inputs,
+                                    Collection<? super Word<I>> states,
+                                    Collection<? super Word<I>> transitions) {
+        cover(automaton, inputs, automaton.getInitialState(), states::add, transitions::add);
     }
 
-    private static <S, I> void cover(DeterministicAutomaton<S, I, ?> automaton,
-                                     Collection<? extends I> inputs,
-                                     Consumer<? super Word<I>> states,
-                                     Consumer<? super Word<I>> transitions) {
+    /**
+     * Computes the state and transition covers for a given automaton beginning in the given state.
+     * <p>
+     * A state cover is a set <i>C</i> of input sequences, such that for each state <i>s</i> of an automaton, there
+     * exists an input sequence in <i>C</i> that transitions the automaton from its initial state to state s.
+     * <p>
+     * A transition cover is a set <i>C</i> of input sequences, such that for each state <i>s</i> and each input symbol
+     * <i>i</i> of an automaton, there exists an input sequence in <i>C</i> that starts from the initial state of the
+     * automaton and ends with the transition that applies <i>i</i> to state <i>s</i>.
+     * <p>
+     * Note: if restrictions on the {@code inputs} parameter do not allow to reach certain states or transitions, the
+     * computed covers are not complete.
+     *
+     * @param automaton
+     *         the automaton for which the covers should be computed
+     * @param inputs
+     *         the set of input symbols allowed in the cover sequences
+     * @param start
+     *         the state from which to begin the computation of overs
+     * @param states
+     *         a consumer that accepts the state cover sequences
+     * @param transitions
+     *         a consumer that accepts the transition cover sequences
+     * @param <S>
+     *         automaton state type
+     * @param <I>
+     *         input symbol type
+     *
+     * @return a mapping from automaton states to their access sequences
+     */
+    public static <S, I> Mapping<S, @Nullable Word<I>> cover(DeterministicAutomaton<S, I, ?> automaton,
+                                                             Collection<? extends I> inputs,
+                                                             @Nullable S start,
+                                                             Consumer<? super Word<I>> states,
+                                                             Consumer<? super Word<I>> transitions) {
 
-        S init = automaton.getInitialState();
+        MutableMapping<S, @Nullable Word<I>> reach = automaton.createStaticStateMapping();
 
-        if (init == null) {
-            return;
+        if (start == null) {
+            return reach;
         }
 
-        MutableMapping<S, Word<I>> reach = automaton.createStaticStateMapping();
-        reach.put(init, Word.epsilon());
+        reach.put(start, Word.epsilon());
 
         Queue<S> bfsQueue = new ArrayDeque<>();
-        bfsQueue.add(init);
+        bfsQueue.add(start);
 
         states.accept(Word.epsilon());
 
@@ -210,6 +250,8 @@ public final class Covers {
                 transitions.accept(succAs);
             }
         }
+
+        return reach;
     }
 
     /**

--- a/util/src/main/java/net/automatalib/util/automaton/procedural/SPAs.java
+++ b/util/src/main/java/net/automatalib/util/automaton/procedural/SPAs.java
@@ -277,7 +277,7 @@ public final class SPAs {
 
         final List<Word<I>> result = new ArrayList<>(inputs.size());
         final UniversalGraph<S, TransitionEdge<I, S>, ?, ?> tgv = dfa.transitionGraphView(inputs);
-        final APSPResult<S, TransitionEdge<I, S>> apsp = Graphs.findAPSP(tgv, edge -> 0F);
+        final APSPResult<S, TransitionEdge<I, S>> apsp = Graphs.findAPSP(tgv);
 
         final List<S> acceptingStates = new ArrayList<>(dfa.size());
         for (S s : dfa) {

--- a/util/src/main/java/net/automatalib/util/graph/Graphs.java
+++ b/util/src/main/java/net/automatalib/util/graph/Graphs.java
@@ -96,6 +96,25 @@ public final class Graphs {
 
     /**
      * Computes the shortest paths between all pairs of nodes in a graph, using the Floyd-Warshall dynamic programming
+     * algorithm. This method assumes no edge weights.
+     *
+     * @param graph
+     *         the graph
+     * @param <N>
+     *         node type
+     * @param <E>
+     *         edge type
+     *
+     * @return the all pairs shortest paths result
+     *
+     * @see FloydWarshallAPSP
+     */
+    public static <N, E> APSPResult<N, E> findAPSP(Graph<N, E> graph) {
+        return findAPSP(graph, e -> 0F);
+    }
+
+    /**
+     * Computes the shortest paths between all pairs of nodes in a graph, using the Floyd-Warshall dynamic programming
      * algorithm. Note that the result is only correct if the graph contains no cycles with negative edge weight sums.
      *
      * @param graph

--- a/util/src/test/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIteratorTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIteratorTest.java
@@ -1,0 +1,63 @@
+/* Copyright (C) 2013-2025 TU Dortmund University
+ * This file is part of AutomataLib <https://automatalib.net>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.automatalib.util.automaton.conformance;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import net.automatalib.alphabet.Alphabet;
+import net.automatalib.alphabet.impl.Alphabets;
+import net.automatalib.automaton.UniversalDeterministicAutomaton;
+import net.automatalib.automaton.fsa.impl.CompactDFA;
+import net.automatalib.common.util.collection.IteratorUtil;
+import net.automatalib.util.automaton.random.RandomAutomata;
+import net.automatalib.word.Word;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@Test
+public class KWayStateCoverTestsIteratorTest {
+
+    @Test
+    public void testDefault() {
+
+        Random random = new Random(42);
+        Alphabet<Integer> alphabet = Alphabets.integers(0, 9);
+        CompactDFA<Integer> dfa = RandomAutomata.randomDFA(random, 10, alphabet);
+
+        KWayStateCoverTestsIterator<?, Integer, ?, ?> iter = new KWayStateCoverTestsIterator<>(dfa, alphabet, random);
+
+        List<Word<Integer>> tests = IteratorUtil.list(iter);
+
+        assertStateCoverage(dfa, tests);
+
+    }
+
+    private <S, I, T> void assertStateCoverage(UniversalDeterministicAutomaton<S, I, T, ?, ?> automaton,
+                                               Collection<Word<I>> tests) {
+
+        Set<S> cache = new HashSet<>();
+
+        for (Word<I> test : tests) {
+            cache.add(automaton.getState(test));
+        }
+
+        Assert.assertEquals(cache.size(), automaton.size());
+    }
+}

--- a/util/src/test/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIteratorTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIteratorTest.java
@@ -15,7 +15,6 @@
  */
 package net.automatalib.util.automaton.conformance;
 
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
@@ -25,39 +24,144 @@ import net.automatalib.alphabet.Alphabet;
 import net.automatalib.alphabet.impl.Alphabets;
 import net.automatalib.automaton.UniversalDeterministicAutomaton;
 import net.automatalib.automaton.fsa.impl.CompactDFA;
+import net.automatalib.automaton.transducer.impl.CompactMealy;
+import net.automatalib.common.util.HashUtil;
 import net.automatalib.common.util.collection.IteratorUtil;
+import net.automatalib.util.automaton.conformance.KWayStateCoverTestsIterator.CombinationMethod;
 import net.automatalib.util.automaton.random.RandomAutomata;
 import net.automatalib.word.Word;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Test
 public class KWayStateCoverTestsIteratorTest {
 
-    @Test
-    public void testDefault() {
+    private static final Alphabet<Character> ALPHABET = Alphabets.characters('a', 'c');
 
-        Random random = new Random(42);
-        Alphabet<Integer> alphabet = Alphabets.integers(0, 9);
-        CompactDFA<Integer> dfa = RandomAutomata.randomDFA(random, 10, alphabet);
-
-        KWayStateCoverTestsIterator<?, Integer, ?, ?> iter = new KWayStateCoverTestsIterator<>(dfa, alphabet, random);
-
-        List<Word<Integer>> tests = IteratorUtil.list(iter);
-
-        assertStateCoverage(dfa, tests);
-
+    @DataProvider(name = "methods")
+    public static Object[][] getMethods() {
+        return new Object[][] {{CombinationMethod.COMBINATIONS}, {CombinationMethod.PERMUTATIONS}};
     }
 
-    private <S, I, T> void assertStateCoverage(UniversalDeterministicAutomaton<S, I, T, ?, ?> automaton,
-                                               Collection<Word<I>> tests) {
+    @Test
+    public void testEmptyAutomaton() {
+        final CompactDFA<Character> dfa = new CompactDFA<>(ALPHABET);
+        final List<Word<Character>> tests = IteratorUtil.list(new KWayStateCoverTestsIterator<>(dfa, ALPHABET));
 
-        Set<S> cache = new HashSet<>();
+        Assert.assertTrue(tests.isEmpty());
+    }
 
-        for (Word<I> test : tests) {
-            cache.add(automaton.getState(test));
+    @Test(dataProvider = "methods")
+    public void testSingleStateAutomaton(CombinationMethod method) {
+        final CompactDFA<Character> dfa = new CompactDFA<>(ALPHABET);
+
+        final int initial = dfa.addIntInitialState();
+        for (int i = 0; i < ALPHABET.size(); i++) {
+            dfa.setTransition(initial, i, initial);
         }
 
-        Assert.assertEquals(cache.size(), automaton.size());
+        final int length = KWayStateCoverTestsIterator.DEFAULT_R_WALK_LEN;
+        final List<Word<Character>> tests = IteratorUtil.list(new KWayStateCoverTestsIterator<>(dfa,
+                                                                                                ALPHABET,
+                                                                                                new Random(42),
+                                                                                                length,
+                                                                                                KWayStateCoverTestsIterator.DEFAULT_K,
+                                                                                                method));
+
+        // check that the first 'length' queries are the randomly generated ones.
+        Assert.assertTrue(tests.size() >= length);
+        for (Word<Character> t : tests.subList(0, length)) {
+            Assert.assertEquals(t.size(), length);
+        }
+    }
+
+    @Test(dataProvider = "methods")
+    public void testNoInitialStateAutomaton(CombinationMethod method) {
+        final CompactDFA<Character> dfa = RandomAutomata.randomDFA(new Random(42), 10, ALPHABET);
+
+        dfa.setInitialState(null);
+        final List<Word<Character>> tests = IteratorUtil.list(new KWayStateCoverTestsIterator<>(dfa,
+                                                                                                ALPHABET,
+                                                                                                new Random(42),
+                                                                                                KWayStateCoverTestsIterator.DEFAULT_R_WALK_LEN,
+                                                                                                KWayStateCoverTestsIterator.DEFAULT_K,
+                                                                                                method));
+
+        Assert.assertTrue(tests.isEmpty());
+    }
+
+    @Test(dataProvider = "methods")
+    public void testRandomAutomaton(CombinationMethod method) {
+        final CompactMealy<Character, Integer> mealy =
+                RandomAutomata.randomMealy(new Random(42), 10, ALPHABET, Alphabets.integers(0, 2));
+
+        final List<Word<Character>> tests = IteratorUtil.list(new KWayStateCoverTestsIterator<>(mealy,
+                                                                                                ALPHABET,
+                                                                                                new Random(42),
+                                                                                                KWayStateCoverTestsIterator.DEFAULT_R_WALK_LEN,
+                                                                                                KWayStateCoverTestsIterator.DEFAULT_K,
+                                                                                                method));
+
+        verifyEachStateVisited(mealy, tests);
+    }
+
+    @Test(dataProvider = "methods")
+    public void testKeylockAutomaton(CombinationMethod method) {
+        final CompactDFA<Character> mealy = generateKeylockAutomaton(ALPHABET);
+
+        final List<Word<Character>> tests = IteratorUtil.list(new KWayStateCoverTestsIterator<>(mealy,
+                                                                                                ALPHABET,
+                                                                                                new Random(42),
+                                                                                                KWayStateCoverTestsIterator.DEFAULT_R_WALK_LEN,
+                                                                                                KWayStateCoverTestsIterator.DEFAULT_K,
+                                                                                                method));
+
+        verifyEachStateVisited(mealy, tests);
+    }
+
+    static <S, I> void verifyEachStateVisited(UniversalDeterministicAutomaton<S, I, ?, ?, ?> automaton,
+                                              List<Word<I>> tests) {
+        final Set<S> visited = new HashSet<>(HashUtil.capacity(automaton.size()));
+
+        final S init = automaton.getInitialState();
+        Assert.assertNotNull(init);
+
+        visited.add(init);
+
+        for (Word<I> t : tests) {
+            S iter = init;
+            for (I i : t) {
+                S succ = automaton.getSuccessor(iter, i);
+                Assert.assertNotNull(succ);
+                visited.add(succ);
+                iter = succ;
+            }
+        }
+
+        Assert.assertEquals(visited, new HashSet<>(automaton.getStates()));
+    }
+
+    static <I> CompactDFA<I> generateKeylockAutomaton(Alphabet<I> alphabet) {
+
+        final CompactDFA<I> result = new CompactDFA<>(alphabet);
+
+        int iter = result.addIntInitialState();
+
+        for (int i = 0; i < 10 - 1; i++) {
+            for (int j = 1; j < alphabet.size(); j++) {
+                result.setTransition(iter, j, iter);
+            }
+            int next = result.addIntState();
+            result.setTransition(iter, 0, next);
+            iter = next;
+        }
+
+        result.setAccepting(iter, true);
+        for (int i = 0; i < alphabet.size(); i++) {
+            result.setTransition(iter, i, iter);
+        }
+
+        return result;
     }
 }

--- a/util/src/test/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIteratorTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIteratorTest.java
@@ -27,6 +27,7 @@ import net.automatalib.automaton.fsa.impl.CompactDFA;
 import net.automatalib.automaton.transducer.impl.CompactMealy;
 import net.automatalib.common.util.HashUtil;
 import net.automatalib.common.util.collection.IteratorUtil;
+import net.automatalib.util.automaton.builder.AutomatonBuilders;
 import net.automatalib.util.automaton.conformance.KWayStateCoverTestsIterator.CombinationMethod;
 import net.automatalib.util.automaton.random.RandomAutomata;
 import net.automatalib.word.Word;
@@ -92,6 +93,26 @@ public class KWayStateCoverTestsIteratorTest {
     }
 
     @Test(dataProvider = "methods")
+    public void testPartialAutomaton(CombinationMethod method) {
+        // @formatter:off
+        final CompactDFA<Character> dfa = AutomatonBuilders.newDFA(ALPHABET)
+                                                           .from("s0").on('a').to("s1")
+                                                           .from("s1").on('b').to("s2")
+                                                           .withInitial("s0")
+                                                           .withAccepting("s2", "s3")
+                                                           .create();
+        // @formatter:on
+
+        final List<Word<Character>> tests = IteratorUtil.list(new KWayStateCoverTestsIterator<>(dfa,
+                                                                                                ALPHABET,
+                                                                                                new Random(42),
+                                                                                                KWayStateCoverTestsIterator.DEFAULT_R_WALK_LEN,
+                                                                                                KWayStateCoverTestsIterator.DEFAULT_K,
+                                                                                                method));
+        verifyEachStateVisited(dfa, tests, Set.of(0, 1, 2));
+    }
+
+    @Test(dataProvider = "methods")
     public void testRandomAutomaton(CombinationMethod method) {
         final CompactMealy<Character, Integer> mealy =
                 RandomAutomata.randomMealy(new Random(42), 10, ALPHABET, Alphabets.integers(0, 2));
@@ -122,6 +143,12 @@ public class KWayStateCoverTestsIteratorTest {
 
     static <S, I> void verifyEachStateVisited(UniversalDeterministicAutomaton<S, I, ?, ?, ?> automaton,
                                               List<Word<I>> tests) {
+        verifyEachStateVisited(automaton, tests, new HashSet<>(automaton.getStates()));
+    }
+
+    static <S, I> void verifyEachStateVisited(UniversalDeterministicAutomaton<S, I, ?, ?, ?> automaton,
+                                              List<Word<I>> tests,
+                                              Set<S> expected) {
         final Set<S> visited = new HashSet<>(HashUtil.capacity(automaton.size()));
 
         final S init = automaton.getInitialState();
@@ -133,13 +160,15 @@ public class KWayStateCoverTestsIteratorTest {
             S iter = init;
             for (I i : t) {
                 S succ = automaton.getSuccessor(iter, i);
-                Assert.assertNotNull(succ);
+                if (succ == null) {
+                    break;
+                }
                 visited.add(succ);
                 iter = succ;
             }
         }
 
-        Assert.assertEquals(visited, new HashSet<>(automaton.getStates()));
+        Assert.assertEquals(visited, expected);
     }
 
     static <I> CompactDFA<I> generateKeylockAutomaton(Alphabet<I> alphabet) {

--- a/util/src/test/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIteratorTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/conformance/KWayStateCoverTestsIteratorTest.java
@@ -71,10 +71,8 @@ public class KWayStateCoverTestsIteratorTest {
                                                                                                 method));
 
         // check that the first 'length' queries are the randomly generated ones.
-        Assert.assertTrue(tests.size() >= length);
-        for (Word<Character> t : tests.subList(0, length)) {
-            Assert.assertEquals(t.size(), length);
-        }
+        Assert.assertEquals(tests.size(), 1);
+        Assert.assertEquals(tests.get(0).length(), length);
     }
 
     @Test(dataProvider = "methods")

--- a/util/src/test/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIteratorTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIteratorTest.java
@@ -15,64 +15,122 @@
  */
 package net.automatalib.util.automaton.conformance;
 
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Random;
-import java.util.Set;
 
 import net.automatalib.alphabet.Alphabet;
 import net.automatalib.alphabet.impl.Alphabets;
-import net.automatalib.automaton.UniversalDeterministicAutomaton;
 import net.automatalib.automaton.fsa.impl.CompactDFA;
+import net.automatalib.automaton.transducer.impl.CompactMealy;
 import net.automatalib.common.util.collection.IteratorUtil;
-import net.automatalib.common.util.mapping.MutableMapping;
+import net.automatalib.util.automaton.conformance.KWayTransitionCoverTestsIterator.GenerationMethod;
+import net.automatalib.util.automaton.conformance.KWayTransitionCoverTestsIterator.OptimizationMetric;
 import net.automatalib.util.automaton.random.RandomAutomata;
 import net.automatalib.word.Word;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Test
 public class KWayTransitionCoverTestsIteratorTest {
 
-    @Test
-    public void testDefault() {
+    private static final Alphabet<Character> ALPHABET = Alphabets.characters('a', 'c');
+    private static final int AUTOMATON_SIZE = 10;
 
-        Random random = new Random(42);
-        Alphabet<Integer> alphabet = Alphabets.integers(0, 9);
-        CompactDFA<Integer> dfa = RandomAutomata.randomDFA(random, 10, alphabet);
+    @DataProvider(name = "config")
+    public static Object[][] getConfig() {
+        final Object[][] result = new Object[GenerationMethod.values().length * OptimizationMetric.values().length][];
+        int idx = 0;
 
-        KWayTransitionCoverTestsIterator<?, Integer, ?, ?> iter =
-                new KWayTransitionCoverTestsIterator<>(dfa, alphabet, random);
+        for (GenerationMethod method : GenerationMethod.values()) {
+            for (OptimizationMetric metric : OptimizationMetric.values()) {
+                result[idx++] = new Object[] {method, metric};
+            }
+        }
 
-        List<Word<Integer>> tests = IteratorUtil.list(iter);
-
-        assertTransitionCoverage(dfa, alphabet, tests);
-
+        return result;
     }
 
-    private <S, I, T> void assertTransitionCoverage(UniversalDeterministicAutomaton<S, I, T, ?, ?> automaton,
-                                                    Collection<I> inputs,
-                                                    Collection<Word<I>> tests) {
+    @Test
+    public void testEmptyAutomaton() {
+        final CompactDFA<Character> dfa = new CompactDFA<>(ALPHABET);
+        final List<Word<Character>> tests = IteratorUtil.list(new KWayTransitionCoverTestsIterator<>(dfa, ALPHABET));
 
-        MutableMapping<S, Set<T>> mapping = automaton.createStaticStateMapping();
+        Assert.assertTrue(tests.isEmpty());
+    }
 
-        for (S s : automaton) {
-            mapping.put(s, new HashSet<>());
+    @Test(dataProvider = "config")
+    public void testSingleStateAutomaton(GenerationMethod method, OptimizationMetric metric) {
+        final CompactDFA<Character> dfa = new CompactDFA<>(ALPHABET);
+
+        final int initial = dfa.addIntInitialState();
+        for (int i = 0; i < ALPHABET.size(); i++) {
+            dfa.setTransition(initial, i, initial);
         }
 
-        for (Word<I> test : tests) {
-            S state = automaton.getState(test.prefix(-1));
-            T t = automaton.getTransition(state, test.lastSymbol());
-            mapping.get(state).add(t);
-        }
+        final List<Word<Character>> tests = IteratorUtil.list(new KWayTransitionCoverTestsIterator<>(dfa,
+                                                                                                     ALPHABET,
+                                                                                                     new Random(42),
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_R_WALK_LEN,
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_NUM_GEN_PATHS,
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_MAX_PATH_LENGTH,
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_MAX_NUM_STEPS,
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_K,
+                                                                                                     method,
+                                                                                                     metric));
+        KWayStateCoverTestsIteratorTest.verifyEachStateVisited(dfa, tests);
+    }
 
-        for (S s : automaton) {
-            Set<T> transitions = mapping.get(s);
-            Assert.assertNotNull(transitions);
-            Assert.assertEquals(transitions.size(), inputs.size(), Objects.toString(s));
-        }
+    @Test(dataProvider = "config")
+    public void testNoInitialStateAutomaton(GenerationMethod method, OptimizationMetric metric) {
+        final CompactDFA<Character> dfa = RandomAutomata.randomDFA(new Random(42), AUTOMATON_SIZE, ALPHABET);
 
+        dfa.setInitialState(null);
+        final List<Word<Character>> tests = IteratorUtil.list(new KWayTransitionCoverTestsIterator<>(dfa,
+                                                                                                     ALPHABET,
+                                                                                                     new Random(42),
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_R_WALK_LEN,
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_NUM_GEN_PATHS,
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_MAX_PATH_LENGTH,
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_MAX_NUM_STEPS,
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_K,
+                                                                                                     method,
+                                                                                                     metric));
+        Assert.assertTrue(tests.isEmpty());
+    }
+
+    @Test(dataProvider = "config")
+    public void testRandomAutomaton(GenerationMethod method, OptimizationMetric metric) {
+        final CompactMealy<Character, Integer> mealy =
+                RandomAutomata.randomMealy(new Random(42), AUTOMATON_SIZE, ALPHABET, Alphabets.integers(0, 2));
+
+        final List<Word<Character>> tests = IteratorUtil.list(new KWayTransitionCoverTestsIterator<>(mealy,
+                                                                                                     ALPHABET,
+                                                                                                     new Random(42),
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_R_WALK_LEN,
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_NUM_GEN_PATHS,
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_MAX_PATH_LENGTH,
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_MAX_NUM_STEPS,
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_K,
+                                                                                                     method,
+                                                                                                     metric));
+        KWayStateCoverTestsIteratorTest.verifyEachStateVisited(mealy, tests);
+    }
+
+    @Test(dataProvider = "config")
+    public void testKeylockAutomaton(GenerationMethod method, OptimizationMetric metric) {
+        final CompactDFA<Character> mealy = KWayStateCoverTestsIteratorTest.generateKeylockAutomaton(ALPHABET);
+
+        final List<Word<Character>> tests = IteratorUtil.list(new KWayTransitionCoverTestsIterator<>(mealy,
+                                                                                                     ALPHABET,
+                                                                                                     new Random(42),
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_R_WALK_LEN,
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_NUM_GEN_PATHS,
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_MAX_PATH_LENGTH,
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_MAX_NUM_STEPS,
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_K,
+                                                                                                     method,
+                                                                                                     metric));
+        KWayStateCoverTestsIteratorTest.verifyEachStateVisited(mealy, tests);
     }
 }

--- a/util/src/test/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIteratorTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIteratorTest.java
@@ -101,8 +101,8 @@ public class KWayTransitionCoverTestsIteratorTest {
                                                                                                      KWayTransitionCoverTestsIterator.DEFAULT_MAX_PATH_LENGTH,
                                                                                                      KWayTransitionCoverTestsIterator.DEFAULT_MAX_NUM_STEPS,
                                                                                                      KWayTransitionCoverTestsIterator.DEFAULT_K,
-                                                                                                     method,
-                                                                                                     metric));
+                                                                                                     metric,
+                                                                                                     method));
         KWayStateCoverTestsIteratorTest.verifyEachStateVisited(dfa, tests);
     }
 
@@ -119,8 +119,8 @@ public class KWayTransitionCoverTestsIteratorTest {
                                                                                                      KWayTransitionCoverTestsIterator.DEFAULT_MAX_PATH_LENGTH,
                                                                                                      KWayTransitionCoverTestsIterator.DEFAULT_MAX_NUM_STEPS,
                                                                                                      KWayTransitionCoverTestsIterator.DEFAULT_K,
-                                                                                                     method,
-                                                                                                     metric));
+                                                                                                     metric,
+                                                                                                     method));
         Assert.assertTrue(tests.isEmpty());
     }
 
@@ -137,8 +137,8 @@ public class KWayTransitionCoverTestsIteratorTest {
                                                                                                      KWayTransitionCoverTestsIterator.DEFAULT_MAX_PATH_LENGTH,
                                                                                                      KWayTransitionCoverTestsIterator.DEFAULT_MAX_NUM_STEPS,
                                                                                                      KWayTransitionCoverTestsIterator.DEFAULT_K,
-                                                                                                     method,
-                                                                                                     metric));
+                                                                                                     metric,
+                                                                                                     method));
         KWayStateCoverTestsIteratorTest.verifyEachStateVisited(mealy, tests);
     }
 
@@ -154,8 +154,8 @@ public class KWayTransitionCoverTestsIteratorTest {
                                                                                                      KWayTransitionCoverTestsIterator.DEFAULT_MAX_PATH_LENGTH,
                                                                                                      KWayTransitionCoverTestsIterator.DEFAULT_MAX_NUM_STEPS,
                                                                                                      KWayTransitionCoverTestsIterator.DEFAULT_K,
-                                                                                                     method,
-                                                                                                     metric));
+                                                                                                     metric,
+                                                                                                     method));
         KWayStateCoverTestsIteratorTest.verifyEachStateVisited(mealy, tests);
     }
 
@@ -174,8 +174,8 @@ public class KWayTransitionCoverTestsIteratorTest {
                                                                                                         KWayTransitionCoverTestsIterator.DEFAULT_MAX_PATH_LENGTH,
                                                                                                         KWayTransitionCoverTestsIterator.DEFAULT_MAX_NUM_STEPS,
                                                                                                         KWayTransitionCoverTestsIterator.DEFAULT_K,
-                                                                                                        GenerationMethod.PREFIX,
-                                                                                                        OptimizationMetric.QUERIES));
+                                                                                                        OptimizationMetric.QUERIES,
+                                                                                                        GenerationMethod.PREFIX));
 
         for (Word<Integer> t : rWalkTests) {
             Assert.assertTrue(t.size() > randomWalkLen, t.toString());
@@ -190,8 +190,8 @@ public class KWayTransitionCoverTestsIteratorTest {
                                                                                                           maxPathLength,
                                                                                                           KWayTransitionCoverTestsIterator.DEFAULT_MAX_NUM_STEPS,
                                                                                                           KWayTransitionCoverTestsIterator.DEFAULT_K,
-                                                                                                          GenerationMethod.RANDOM,
-                                                                                                          OptimizationMetric.QUERIES));
+                                                                                                          OptimizationMetric.QUERIES,
+                                                                                                          GenerationMethod.RANDOM));
 
         for (Word<Integer> t : maxPathTests) {
             Assert.assertTrue(t.size() <= maxPathLength, t.toString());
@@ -206,8 +206,8 @@ public class KWayTransitionCoverTestsIteratorTest {
                                                                                                               KWayTransitionCoverTestsIterator.DEFAULT_MAX_PATH_LENGTH,
                                                                                                               maxNumSteps,
                                                                                                               KWayTransitionCoverTestsIterator.DEFAULT_K,
-                                                                                                              GenerationMethod.RANDOM,
-                                                                                                              OptimizationMetric.STEPS));
+                                                                                                              OptimizationMetric.STEPS,
+                                                                                                              GenerationMethod.RANDOM));
 
         Assert.assertTrue(maxNumStepsTests.stream().mapToInt(Word::size).sum() >= maxNumSteps,
                           maxNumStepsTests.toString());

--- a/util/src/test/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIteratorTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIteratorTest.java
@@ -1,0 +1,78 @@
+/* Copyright (C) 2013-2025 TU Dortmund University
+ * This file is part of AutomataLib <https://automatalib.net>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.automatalib.util.automaton.conformance;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+import java.util.Set;
+
+import net.automatalib.alphabet.Alphabet;
+import net.automatalib.alphabet.impl.Alphabets;
+import net.automatalib.automaton.UniversalDeterministicAutomaton;
+import net.automatalib.automaton.fsa.impl.CompactDFA;
+import net.automatalib.common.util.collection.IteratorUtil;
+import net.automatalib.common.util.mapping.MutableMapping;
+import net.automatalib.util.automaton.random.RandomAutomata;
+import net.automatalib.word.Word;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@Test
+public class KWayTransitionCoverTestsIteratorTest {
+
+    @Test
+    public void testDefault() {
+
+        Random random = new Random(42);
+        Alphabet<Integer> alphabet = Alphabets.integers(0, 9);
+        CompactDFA<Integer> dfa = RandomAutomata.randomDFA(random, 10, alphabet);
+
+        KWayTransitionCoverTestsIterator<?, Integer, ?, ?> iter =
+                new KWayTransitionCoverTestsIterator<>(dfa, alphabet, random);
+
+        List<Word<Integer>> tests = IteratorUtil.list(iter);
+
+        assertTransitionCoverage(dfa, alphabet, tests);
+
+    }
+
+    private <S, I, T> void assertTransitionCoverage(UniversalDeterministicAutomaton<S, I, T, ?, ?> automaton,
+                                                    Collection<I> inputs,
+                                                    Collection<Word<I>> tests) {
+
+        MutableMapping<S, Set<T>> mapping = automaton.createStaticStateMapping();
+
+        for (S s : automaton) {
+            mapping.put(s, new HashSet<>());
+        }
+
+        for (Word<I> test : tests) {
+            S state = automaton.getState(test.prefix(-1));
+            T t = automaton.getTransition(state, test.lastSymbol());
+            mapping.get(state).add(t);
+        }
+
+        for (S s : automaton) {
+            Set<T> transitions = mapping.get(s);
+            Assert.assertNotNull(transitions);
+            Assert.assertEquals(transitions.size(), inputs.size(), Objects.toString(s));
+        }
+
+    }
+}

--- a/util/src/test/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIteratorTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIteratorTest.java
@@ -24,6 +24,7 @@ import net.automatalib.alphabet.impl.Alphabets;
 import net.automatalib.automaton.fsa.impl.CompactDFA;
 import net.automatalib.automaton.transducer.impl.CompactMealy;
 import net.automatalib.common.util.collection.IteratorUtil;
+import net.automatalib.util.automaton.builder.AutomatonBuilders;
 import net.automatalib.util.automaton.conformance.KWayTransitionCoverTestsIterator.GenerationMethod;
 import net.automatalib.util.automaton.conformance.KWayTransitionCoverTestsIterator.OptimizationMetric;
 import net.automatalib.util.automaton.random.RandomAutomata;
@@ -125,6 +126,30 @@ public class KWayTransitionCoverTestsIteratorTest {
     }
 
     @Test(dataProvider = "config")
+    public void testPartialAutomaton(GenerationMethod method, OptimizationMetric metric) {
+        // @formatter:off
+        final CompactDFA<Character> dfa = AutomatonBuilders.newDFA(ALPHABET)
+                                                           .from("s0").on('a').to("s1")
+                                                           .from("s1").on('b').to("s2")
+                                                           .withInitial("s0")
+                                                           .withAccepting("s2", "s3")
+                                                           .create();
+        // @formatter:on
+
+        final List<Word<Character>> tests = IteratorUtil.list(new KWayTransitionCoverTestsIterator<>(dfa,
+                                                                                                     ALPHABET,
+                                                                                                     new Random(42),
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_R_WALK_LEN,
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_NUM_GEN_PATHS,
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_MAX_PATH_LENGTH,
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_MAX_NUM_STEPS,
+                                                                                                     KWayTransitionCoverTestsIterator.DEFAULT_K,
+                                                                                                     metric,
+                                                                                                     method));
+        KWayStateCoverTestsIteratorTest.verifyEachStateVisited(dfa, tests, Set.of(0, 1, 2));
+    }
+
+    @Test(dataProvider = "config")
     public void testRandomAutomaton(GenerationMethod method, OptimizationMetric metric) {
         final CompactMealy<Character, Integer> mealy =
                 RandomAutomata.randomMealy(new Random(42), AUTOMATON_SIZE, ALPHABET, Alphabets.integers(0, 2));
@@ -185,7 +210,8 @@ public class KWayTransitionCoverTestsIteratorTest {
         final List<Word<Integer>> maxPathTests = IteratorUtil.list(new KWayTransitionCoverTestsIterator<>(dfa,
                                                                                                           alphabet,
                                                                                                           random,
-                                                                                                          KWayTransitionCoverTestsIterator.DEFAULT_R_WALK_LEN,
+                                                                                                          maxPathLength *
+                                                                                                          maxPathLength,
                                                                                                           KWayTransitionCoverTestsIterator.DEFAULT_NUM_GEN_PATHS,
                                                                                                           maxPathLength,
                                                                                                           KWayTransitionCoverTestsIterator.DEFAULT_MAX_NUM_STEPS,
@@ -194,22 +220,29 @@ public class KWayTransitionCoverTestsIteratorTest {
                                                                                                           GenerationMethod.RANDOM));
 
         for (Word<Integer> t : maxPathTests) {
-            Assert.assertTrue(t.size() <= maxPathLength, t.toString());
+            final int length = t.size();
+            /*
+             * In case the random generation can no longer find any meaningful test sequences it re-generates candidates
+             * via the prefix method which uses the randomWalkLength. We make this value reasonably large to check that
+             * test sequences were only generated from these two possibilities.
+             */
+            Assert.assertTrue(length <= maxPathLength || length > maxPathLength * maxPathLength, t.toString());
         }
 
-        final int maxNumSteps = 20;
+        final int maxNumSteps = 10;
         final List<Word<Integer>> maxNumStepsTests = IteratorUtil.list(new KWayTransitionCoverTestsIterator<>(dfa,
                                                                                                               alphabet,
                                                                                                               random,
                                                                                                               KWayTransitionCoverTestsIterator.DEFAULT_R_WALK_LEN,
                                                                                                               KWayTransitionCoverTestsIterator.DEFAULT_NUM_GEN_PATHS,
-                                                                                                              KWayTransitionCoverTestsIterator.DEFAULT_MAX_PATH_LENGTH,
+                                                                                                              maxPathLength,
                                                                                                               maxNumSteps,
                                                                                                               KWayTransitionCoverTestsIterator.DEFAULT_K,
                                                                                                               OptimizationMetric.STEPS,
                                                                                                               GenerationMethod.RANDOM));
 
-        Assert.assertTrue(maxNumStepsTests.stream().mapToInt(Word::size).sum() >= maxNumSteps,
-                          maxNumStepsTests.toString());
+        final int numSteps = maxNumStepsTests.stream().mapToInt(Word::size).sum();
+        Assert.assertTrue(numSteps >= maxNumSteps, maxNumStepsTests.toString());
+        Assert.assertTrue(numSteps <= maxNumSteps + maxPathLength, maxNumStepsTests.toString());
     }
 }

--- a/util/src/test/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIteratorTest.java
+++ b/util/src/test/java/net/automatalib/util/automaton/conformance/KWayTransitionCoverTestsIteratorTest.java
@@ -17,6 +17,7 @@ package net.automatalib.util.automaton.conformance;
 
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 
 import net.automatalib.alphabet.Alphabet;
 import net.automatalib.alphabet.impl.Alphabets;
@@ -49,6 +50,30 @@ public class KWayTransitionCoverTestsIteratorTest {
         }
 
         return result;
+    }
+
+    @Test
+    public void testSizeOfSetDifference() {
+        final Set<Character> s1 = Set.of('A', 'B', 'C');
+        final Set<Character> s2 = Set.of('A', 'B');
+        final Set<Character> s3 = Set.of('A');
+        final Set<Character> s4 = Set.of('X', 'Y', 'Z');
+        final Set<Character> s5 = Set.of('A', 'X');
+
+        Assert.assertEquals(KWayTransitionCoverTestsIterator.sizeOfSetDifference(s1, s2), 1);
+        Assert.assertEquals(KWayTransitionCoverTestsIterator.sizeOfSetDifference(s2, s1), 0);
+
+        Assert.assertEquals(KWayTransitionCoverTestsIterator.sizeOfSetDifference(s1, s3), 2);
+        Assert.assertEquals(KWayTransitionCoverTestsIterator.sizeOfSetDifference(s3, s1), 0);
+
+        Assert.assertEquals(KWayTransitionCoverTestsIterator.sizeOfSetDifference(s1, s4), 3);
+        Assert.assertEquals(KWayTransitionCoverTestsIterator.sizeOfSetDifference(s4, s1), 3);
+
+        Assert.assertEquals(KWayTransitionCoverTestsIterator.sizeOfSetDifference(s1, s5), 2);
+        Assert.assertEquals(KWayTransitionCoverTestsIterator.sizeOfSetDifference(s5, s1), 1);
+
+        Assert.assertEquals(KWayTransitionCoverTestsIterator.sizeOfSetDifference(s4, s5), 2);
+        Assert.assertEquals(KWayTransitionCoverTestsIterator.sizeOfSetDifference(s5, s4), 1);
     }
 
     @Test
@@ -132,5 +157,59 @@ public class KWayTransitionCoverTestsIteratorTest {
                                                                                                      method,
                                                                                                      metric));
         KWayStateCoverTestsIteratorTest.verifyEachStateVisited(mealy, tests);
+    }
+
+    @Test
+    public void testLimits() {
+        final Random random = new Random(42);
+        final Alphabet<Integer> alphabet = Alphabets.integers(0, 6);
+        final CompactDFA<Integer> dfa = RandomAutomata.randomDFA(random, 10, alphabet, false);
+        final int randomWalkLen = 50;
+
+        final List<Word<Integer>> rWalkTests = IteratorUtil.list(new KWayTransitionCoverTestsIterator<>(dfa,
+                                                                                                        alphabet,
+                                                                                                        random,
+                                                                                                        randomWalkLen,
+                                                                                                        KWayTransitionCoverTestsIterator.DEFAULT_NUM_GEN_PATHS,
+                                                                                                        KWayTransitionCoverTestsIterator.DEFAULT_MAX_PATH_LENGTH,
+                                                                                                        KWayTransitionCoverTestsIterator.DEFAULT_MAX_NUM_STEPS,
+                                                                                                        KWayTransitionCoverTestsIterator.DEFAULT_K,
+                                                                                                        GenerationMethod.PREFIX,
+                                                                                                        OptimizationMetric.QUERIES));
+
+        for (Word<Integer> t : rWalkTests) {
+            Assert.assertTrue(t.size() > randomWalkLen, t.toString());
+        }
+
+        final int maxPathLength = 10;
+        final List<Word<Integer>> maxPathTests = IteratorUtil.list(new KWayTransitionCoverTestsIterator<>(dfa,
+                                                                                                          alphabet,
+                                                                                                          random,
+                                                                                                          KWayTransitionCoverTestsIterator.DEFAULT_R_WALK_LEN,
+                                                                                                          KWayTransitionCoverTestsIterator.DEFAULT_NUM_GEN_PATHS,
+                                                                                                          maxPathLength,
+                                                                                                          KWayTransitionCoverTestsIterator.DEFAULT_MAX_NUM_STEPS,
+                                                                                                          KWayTransitionCoverTestsIterator.DEFAULT_K,
+                                                                                                          GenerationMethod.RANDOM,
+                                                                                                          OptimizationMetric.QUERIES));
+
+        for (Word<Integer> t : maxPathTests) {
+            Assert.assertTrue(t.size() <= maxPathLength, t.toString());
+        }
+
+        final int maxNumSteps = 20;
+        final List<Word<Integer>> maxNumStepsTests = IteratorUtil.list(new KWayTransitionCoverTestsIterator<>(dfa,
+                                                                                                              alphabet,
+                                                                                                              random,
+                                                                                                              KWayTransitionCoverTestsIterator.DEFAULT_R_WALK_LEN,
+                                                                                                              KWayTransitionCoverTestsIterator.DEFAULT_NUM_GEN_PATHS,
+                                                                                                              KWayTransitionCoverTestsIterator.DEFAULT_MAX_PATH_LENGTH,
+                                                                                                              maxNumSteps,
+                                                                                                              KWayTransitionCoverTestsIterator.DEFAULT_K,
+                                                                                                              GenerationMethod.RANDOM,
+                                                                                                              OptimizationMetric.STEPS));
+
+        Assert.assertTrue(maxNumStepsTests.stream().mapToInt(Word::size).sum() >= maxNumSteps,
+                          maxNumStepsTests.toString());
     }
 }


### PR DESCRIPTION
This PR adds randomized conformance test generators based on the concepts of mutation testing as described in the paper [Learning from Faults: Mutation Testing in Active Automata Learning](https://doi.org/10.1007/978-3-319-57288-8_2) by Bernhard K. Aichernig and Martin Tappler.