### PR TITLE
CI: replace deprecated macos image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         jdk: [ 17, 21, 25 ]
-        os: [ ubuntu-latest, windows-latest, macos-13, macos-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-15-intel, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout


### PR DESCRIPTION
According to actions/runner-images#13046, `macos-13` has been deprecated and `macos-15-intel` is planned as the last supported MacOS image on Intel CPUs.